### PR TITLE
Get devices by domain

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -31,3 +31,15 @@ taGxAoGAQGFYb63lBeGS2vkUyovP2kMwBF0E6Y+3Il+TGjwPalyg+TyNzEAvkOUe
 2iy8Eul9rT6qcByzNXnNAMRHYhXDWQWmRaHM/lzyIkNr/O3UBEQKiSew/YhH6s1W
 iMwh+x+ekyFOxb98aNqlnEH/7PsQonzWThpzcAAojllTt9AIbbc=
 -----END RSA PRIVATE KEY-----"""
+
+_LEAP_DEVICE_TYPES = {'light': ['WallDimmer', 'PlugInDimmer'],
+                      'switch': ['WallSwitch'],
+                      'cover': ['SerenaHoneycombShade', 'SerenaRollerShade',
+                                'TriathlonHoneycombShade',
+                                'TriathlonRollerShade', 'QsWirelessShade'],
+                      'sensor': ['Pico1Button', 'Pico2Button',
+                                 'Pico2ButtonRaiseLower', 'Pico3Button',
+                                 'Pico3ButtonRaiseLower', 'Pico4Button',
+                                 'Pico4ButtonScene', 'Pico4ButtonZone',
+                                 'Pico4Button2Group', 'FourGroupRemote']
+                      }

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -1,6 +1,6 @@
-"""This module provides an API to communicate with the Caseta Smartbridge."""
+"""An API to communicate with the Lutron Caseta Smart Bridge."""
 
-# This is the private key for the lutron smartbridge 'leap' user.
+# This is the private key for the Lutron Smart Bridge 'leap' user.
 # https://github.com/njschwartz/Lutron-Smart-Pi/blob/master/RaspberryPi/LutronPi.py
 
 _LUTRON_SSH_KEY = """\

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -1,4 +1,4 @@
-"""Provides an API to interact with the Lutron Caseta Smartbridge."""
+"""Provides an API to interact with the Lutron Caseta Smart Bridge."""
 
 import json
 import logging
@@ -16,14 +16,13 @@ _LOG.setLevel(logging.DEBUG)
 
 class Smartbridge:
     """
-    This class acts as a representation of the lutron caseta smartbridge.
+    A representation of the Lutron Caseta Smart Bridge.
 
-    It uses telnet as documented here:
-    http://www.lutron.com/TechnicalDocumentLibrary/040249.pdf
+    It uses an SSH interface known as the LEAP server.
     """
 
     def __init__(self, hostname=None):
-        """Setup the Smartbridge."""
+        """Setup the Smart Bridge."""
         self.devices = {}
         self.scenes = {}
         self._hostname = hostname
@@ -42,44 +41,71 @@ class Smartbridge:
             self.get_value(_id)
         self._subscribers = {}
 
-    def add_subscriber(self, device_id, _callback):
-        """Add a listener to be notified of state changes."""
-        self._subscribers[device_id] = _callback
+    def add_subscriber(self, device_id, callback_):
+        """
+        Add a listener to be notified of state changes.
+
+        :param device_id: device id, e.g. 5
+        :param callback_: callback to invoke
+        """
+        self._subscribers[device_id] = callback_
 
     def get_devices(self):
-        """Will return all known devices connected to the Smartbridge."""
+        """Will return all known devices connected to the Smart Bridge."""
         return self.devices
 
-    def get_devices_by_type(self, _type):
-        """Will return all devices of a given type."""
+    def get_devices_by_type(self, type_):
+        """
+        Will return all devices of a given device type.
+
+        :param type_: LEAP device type, e.g. WallSwitch
+        """
         devs = []
         for device_id in self.devices:
-            if self.devices[device_id]['type'] == _type:
+            if self.devices[device_id]['type'] == type_:
                 devs.append(self.devices[device_id])
         return devs
 
-    def get_devices_by_types(self, _types):
-        """Will return all devices of for a list of given types."""
+    def get_devices_by_types(self, types):
+        """
+        Will return all devices of for a list of given device types.
+
+        :param types: list of LEAP device types such as WallSwitch, WallDimmer
+        """
         devs = []
         for device_id in self.devices:
-            if self.devices[device_id]['type'] in _types:
+            if self.devices[device_id]['type'] in types:
                 devs.append(self.devices[device_id])
         return devs
 
     def get_device_by_id(self, device_id):
-        """Will return a device with the given ID."""
+        """
+        Will return a device with the given ID.
+
+        :param device_id: device id, e.g. 5
+        """
         return self.devices[device_id]
 
     def get_scenes(self):
-        """Will return all known scenes connected to the Smartbridge."""
+        """Will return all known scenes from the Smart Bridge."""
         return self.scenes
 
     def get_scene_by_id(self, scene_id):
-        """Will return a scene with the scene ID."""
+        """
+        Will return a scene with the given scene ID.
+
+        :param scene_id: scene id, e.g 23
+        """
         return self.scenes[scene_id]
 
     def get_value(self, device_id):
-        """Will return the current value for the device with the given ID."""
+        """
+        Will return the current level value for the device with the given ID.
+
+        :param device_id: device id, e.g. 5
+        :returns level value from 0 to 100
+        :rtype int
+        """
         zone_id = self._get_zone_id(device_id)
         cmd = '{"CommuniqueType":"ReadRequest",' \
               '"Header":{"Url":"/zone/%s/status"}}\n' % zone_id
@@ -87,15 +113,25 @@ class Smartbridge:
             return self._send_ssh_command(cmd)
 
     def is_connected(self):
-        """Will return True if currently connected ot the Smartbridge."""
+        """Will return True if currently connected to the Smart Bridge."""
         return self.logged_in
 
     def is_on(self, device_id):
-        """Will return True is the device with the given ID is 'on'."""
+        """
+        Will return True is the device with the given ID is 'on'.
+
+        :param device_id: device id, e.g. 5
+        :returns True if level is greater than 0 level, False otherwise
+        """
         return self.devices[device_id]['current_state'] > 0
 
     def set_value(self, device_id, value):
-        """Will set the value for a device with the given ID."""
+        """
+        Will set the value for a device with the given ID.
+
+        :param device_id: device id to set the value on
+        :param value: integer value from 0 to 100 to set
+        """
         zone_id = self._get_zone_id(device_id)
         if zone_id:
             cmd = '{"CommuniqueType":"CreateRequest",' \
@@ -106,32 +142,51 @@ class Smartbridge:
             return self._send_ssh_command(cmd)
 
     def turn_on(self, device_id):
-        """Will turn 'on' the device with the given ID."""
+        """
+        Will turn 'on' the device with the given ID.
+
+        :param device_id: device id to turn on
+        """
         return self.set_value(device_id, 100)
 
     def turn_off(self, device_id):
-        """Will turn 'off' the device with the given ID."""
+        """
+        Will turn 'off' the device with the given ID.
+
+        :param device_id: device id to turn off
+        """
         return self.set_value(device_id, 0)
 
     def activate_scene(self, scene_id):
-        """Will activate the scene with the given ID."""
+        """
+        Will activate the scene with the given ID.
+
+        :param scene_id: scene id, e.g. 23
+        """
         if scene_id in self.scenes:
             cmd = '{"CommuniqueType":"CreateRequest",' \
-                    '"Header":{"Url":"/virtualbutton/%s/commandprocessor"},' \
-                    '"Body":{"Command":{"CommandType":"PressAndRelease"}}}' \
-                    '\n' % (scene_id)
+                  '"Header":{"Url":"/virtualbutton/%s/commandprocessor"},' \
+                  '"Body":{"Command":{"CommandType":"PressAndRelease"}}}' \
+                  '\n' % scene_id
             return self._send_ssh_command(cmd)
 
     def _get_zone_id(self, device_id):
+        """
+        Returns the zone id for an given device.
+
+        :param device_id: device id for which to retrieve a zone id
+        """
         device = self.devices[device_id]
         if 'zone' in device:
             return device['zone']
         return None
 
     def _send_ssh_command(self, cmd):
+        """Sends an SSH command to the SSH shell."""
         self._ssh_shell.send(cmd)
 
     def _monitor(self):
+        """Event monitoring loop for the SSH shell."""
         while True:
             try:
                 self._login_ssh()
@@ -140,21 +195,30 @@ class Smartbridge:
                 resp_parts = response.split(b'\r\n')
                 try:
                     for resp in resp_parts:
-                        if len(resp) > 0:
+                        if resp:
                             resp_json = json.loads(resp.decode("UTF-8"))
-                            self._handle_respose(resp_json)
+                            self._handle_response(resp_json)
                 except ValueError:
-                    _LOG.error('Invalid response '
-                               'from SmartBridge: ' + response.decode("UTF-8"))
+                    _LOG.error("Invalid response "
+                               "from SmartBridge: " + response.decode("UTF-8"))
             except ConnectionError:
                 self.logged_in = False
 
-    def _handle_respose(self, resp_json):
+    def _handle_response(self, resp_json):
+        """
+        Handles an event from the SSH interface.
+
+        If a zone level was changed either by external means such as a Pico
+        remote or by a command sent from us, the new level will appear on the
+        SSH shell and the response is handled by this function.
+
+        :param resp_json: full JSON response from the SSH shell
+        """
         comm_type = resp_json['CommuniqueType']
         if comm_type == 'ReadResponse':
             body = resp_json['Body']
             zone = body['ZoneStatus']['Zone']['href']
-            zone = zone[zone.rfind('/')+1:]
+            zone = zone[zone.rfind('/') + 1:]
             level = body['ZoneStatus']['Level']
             _LOG.debug('zone=%s level=%s', zone, level)
             for _device_id in self.devices:
@@ -167,19 +231,19 @@ class Smartbridge:
 
     def _login_ssh(self):
         """
-        Communicate to the smartbridge sing SSH.
+        Connect and login to the Smart Bridge LEAP server using SSH.
 
-        This interaction over ssh is not really documented anywhere.
+        This interaction over SSH is not really documented anywhere.
         I was looking for a way to get a list of devices connected to
-        the Smartbridge.  I found several references indicating
-        this was possible over ssh.
+        the Smart Bridge. I found several references indicating
+        this was possible over SSH.
         The most complete reference is located here:
         https://github.com/njschwartz/Lutron-Smart-Pi/blob/master/RaspberryPi/LutronPi.py
         """
         if self.logged_in:
             return
 
-        _LOG.debug('Connecting to smartbridge via ssh')
+        _LOG.debug("Connecting to Smart Bridge via SSH")
         ssh_user = 'leap'
         ssh_port = 22
         ssh_key = paramiko.RSAKey.from_private_key(StringIO(_LUTRON_SSH_KEY))
@@ -191,11 +255,13 @@ class Smartbridge:
                                 username=ssh_user, pkey=ssh_key)
 
         self._ssh_shell = self._sshclient.invoke_shell()
-        _LOG.debug('Connected to smartbridge ssh...ready...')
+        _LOG.debug("Successfully connected to Smart Bridge "
+                   "using SSH. Ready...")
         self.logged_in = True
 
     def _load_devices(self):
-        _LOG.debug('Loading devices')
+        """Load the device list from the SSH LEAP server interface."""
+        _LOG.debug("Loading devices")
         self._ssh_shell.send(
             '{"CommuniqueType":"ReadRequest","Header":{"Url":"/device"}}\n')
         time.sleep(1)
@@ -205,11 +271,11 @@ class Smartbridge:
         device_json = json.loads(output_parts[1].decode("UTF-8"))
         for device in device_json['Body']['Devices']:
             _LOG.debug(device)
-            device_id = device['href'][device['href'].rfind('/')+1:]
+            device_id = device['href'][device['href'].rfind('/') + 1:]
             device_zone = None
             if 'LocalZones' in device:
                 device_zone = device['LocalZones'][0]['href']
-                device_zone = device_zone[device_zone.rfind('/')+1:]
+                device_zone = device_zone[device_zone.rfind('/') + 1:]
             device_name = device['Name']
             device_type = device['DeviceType']
             self.devices[device_id] = {'device_id': device_id,
@@ -219,7 +285,12 @@ class Smartbridge:
                                        'current_state': -1}
 
     def _load_scenes(self):
-        _LOG.debug('Loading scenes')
+        """
+        Load the scenes from the Smart Bridge.
+
+        Scenes are known as virtual buttons in the SSH LEAP interface.
+        """
+        _LOG.debug("Loading scenes from the Smart Bridge")
         self._ssh_shell.send(
             '{"CommuniqueType":"ReadRequest","Header":'
             '{"Url":"/virtualbutton"}}\n')
@@ -231,7 +302,7 @@ class Smartbridge:
         for scene in scene_json['Body']['VirtualButtons']:
             _LOG.debug(scene)
             if scene['IsProgrammed']:
-                scene_id = scene['href'][scene['href'].rfind('/')+1:]
+                scene_id = scene['href'][scene['href'].rfind('/') + 1:]
                 scene_name = scene['Name']
                 self.scenes[scene_id] = {'scene_id': scene_id,
                                          'name': scene_name}

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -8,7 +8,7 @@ from io import StringIO
 
 import paramiko
 
-from pylutron_caseta import _LUTRON_SSH_KEY
+from pylutron_caseta import _LUTRON_SSH_KEY, _LEAP_DEVICE_TYPES
 
 _LOG = logging.getLogger('smartbridge')
 _LOG.setLevel(logging.DEBUG)
@@ -53,6 +53,26 @@ class Smartbridge:
     def get_devices(self):
         """Will return all known devices connected to the Smart Bridge."""
         return self.devices
+
+    def get_devices_by_domain(self, domain):
+        """
+        Will return a list of devices for the given domain, such as 'light'
+        or 'switch'.
+
+        :param domain: one of 'light', 'switch', 'cover' or 'sensor'
+        :returns list of zero or more of the devices
+        """
+        devs = []
+
+        # return immediately if not a supported domain
+        if domain not in _LEAP_DEVICE_TYPES:
+            return devs
+
+        # loop over all devices and check their type
+        for device_id in self.devices:
+            if self.devices[device_id]['type'] in _LEAP_DEVICE_TYPES[domain]:
+                devs.append(self.devices[device_id])
+        return devs
 
     def get_devices_by_type(self, type_):
         """


### PR DESCRIPTION
Adding code for issue #8.

First commit, f381de2, adds docstrings for functions, cleans up PEP8 and other minor issues found during development. I've attempted to follow [style guidelines](https://home-assistant.io/developers/development_guidelines/) also used in Home Assistant and to be consistent with spelling, line lengths, use of double-quotes for sentences and other minor style issues. Processed with pylint and flake8.

Second commit 4b7154a is the new method to call from Home Assistant to retrieve devices by their domain such as 'light', 'switch' etc. I've added 'sensor' even though it is not currently used from Home Assistant code. The original methods remain intact and with docstrings added to clarify their intended use.

My first attempt at Python so hopefully I didn't break anything and it makes sense!
