### PR TITLE
Use fully qualified names for devices

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -318,7 +318,7 @@ class Smartbridge:
             if 'LocalZones' in device:
                 device_zone = device['LocalZones'][0]['href']
                 device_zone = device_zone[device_zone.rfind('/') + 1:]
-            device_name = device['Name']
+            device_name = '_'.join(device['FullyQualifiedName'])
             device_type = device['DeviceType']
             self.devices[device_id] = {'device_id': device_id,
                                        'name': device_name,

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -188,7 +188,7 @@ def test_device_list(event_loop, bridge):
             "current_state": -1},
         "2": {
             "device_id": "2",
-            "name": "Lights",
+            "name": "Hallway_Lights",
             "type": "WallDimmer",
             "zone": "1",
             "current_state": -1}}


### PR DESCRIPTION
With enough lights, it gets very easy to have a name collision. In Home Assistant, the device names change each time HASS is restarted, causing unreliable control of devices. Using the fully qualified name fixes this issue by naming devices in a more global fashion.

Fixes #18