### PR TITLE
add model and serial to device listing

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -323,10 +323,14 @@ class Smartbridge:
                 device_zone = device_zone[device_zone.rfind('/') + 1:]
             device_name = '_'.join(device['FullyQualifiedName'])
             device_type = device['DeviceType']
+            device_model = device['ModelNumber']
+            device_serial = device['SerialNumber']
             self.devices[device_id] = {'device_id': device_id,
                                        'name': device_name,
                                        'type': device_type,
                                        'zone': device_zone,
+                                       'model': device_model,
+                                       'serial': device_serial,
                                        'current_state': -1}
 
     @asyncio.coroutine

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -185,12 +185,16 @@ def test_device_list(event_loop, bridge):
             "name": "Smart Bridge",
             "type": "SmartBridge",
             "zone": None,
-            "current_state": -1},
+            "current_state": -1,
+            "model": "L-BDG2-WH",
+            "serial": 1234},
         "2": {
             "device_id": "2",
             "name": "Hallway_Lights",
             "type": "WallDimmer",
             "zone": "1",
+            "model": "PD-6WCL-XX",
+            "serial": 2345,
             "current_state": -1}}
 
     yield from bridge.reader.queue.put({


### PR DESCRIPTION
In order to support the [Home Assistant Entity Registry](https://www.home-assistant.io/docs/configuration/entity-registry/) we need to be able to construct a stable identifier value for every device. I don't know the details of how Lutron issues serial numbers, but I assume a combination of model ID and serial number will be unique within every home.