### PR TITLE
be consistent about how TLS handshaking is done

### DIFF
--- a/get_lutron_cert.py
+++ b/get_lutron_cert.py
@@ -135,7 +135,7 @@ ssl_context.load_cert_chain('caseta.crt', 'caseta.key')
 ssl_context.verify_mode = ssl.CERT_NONE
 
 with socket.create_connection((server_addr, 8081)) as raw_socket:
-    with ssl_context.wrap_socket(raw_socket, server_hostname=server_addr) as ssl_socket:
+    with ssl_context.wrap_socket(raw_socket) as ssl_socket:
         ca_der = ssl_socket.getpeercert(True)
         ca_cert = x509.load_der_x509_certificate(ca_der, default_backend())
         with open('caseta-bridge.crt', 'wb') as f:

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -53,6 +53,7 @@ class Smartbridge:
         def _connect():
             res = yield from open_connection(hostname,
                                              port,
+                                             server_hostname='',
                                              ssl=ssl_context,
                                              loop=loop,
                                              family=socket.AF_INET)


### PR DESCRIPTION
It looks like in a recent firmware update the bridge started sending different certificates when the client sends a server name indication extension (SNI) in TLS client hello message. Unfortunately, pylutron-caseta does send such extensions if run on a version of Python that supports it, but get_lutron_cert.py does not.

At first I tried making get_lutron_cert.py support SNI like smartbridge.py does, but that would mean everybody needs to rerun get_lutron_cert.py to get new certificates. Additionally, when I went to try this on my Home Assistant server I found that it doesn't seem to support SNI so the certificates I'd collected on my desktop did not work on my server, meaning users could encounter cases such as mine where the certificates work until they're placed on the server, but also cases where upgrading Python or OpenSSL or something causes pylutron-caseta to stop working.

Instead, I disabled SNI in both places. This should mean any users affected by the update problem should be able to upgrade to the new pylutron-caseta and that should be enough to get them working again.

I'm not sure why Lutron did this, because the certificates returned with SNI are the same regardless of requested name, do not match the hostname or IP address of the bridge, do not have any alternate names attached, and do not appear to be cryptographically stronger than the old certificates. It doesn't look like the server switches to a new API version either. I think maybe the hostname is supposed to match but somebody messed up and used base 10 encoding instead of base 16 encoding. If that is the case, I'd expect the SNI certificates to change again within the next few months to correct that, which is one more reason to stick with the non-SNI certificates.

Fixes #28 