### PR TITLE
Do not process scenes attached to engraved keypads

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -407,7 +407,7 @@ class Smartbridge:
                 break
         for scene in scene_json['Body']['VirtualButtons']:
             _LOG.debug(scene)
-            if scene['IsProgrammed']:
+            if scene['IsProgrammed'] and 'Name' in scene:
                 scene_id = scene['href'][scene['href'].rfind('/') + 1:]
                 scene_name = scene['Name']
                 self.scenes[scene_id] = {'scene_id': scene_id,

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -136,7 +136,14 @@ class Bridge:
                     "ButtonNumber": 1,
                     "ProgrammingModel": {"href": "/programmingmodel/2"},
                     "Parent": {"href": "/project"},
-                    "IsProgrammed": False}]}})
+                    "IsProgrammed": False
+                }, {
+                    'href': '/vbutton/1',
+                    'ButtonNumber': 1,
+                    'ProgrammingModel': {'href': '/programmingmodel/200'},
+                    'Parent': {'href': '/area/9'},
+                    'IsProgrammed': True,
+                    'Category': {'Type': 'LivingRoom', 'SubType': 'Bright'}}]}})
         requested_zones = []
         for _ in range(0, 2):
             value = yield from wait(writer.queue.get())

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -143,7 +143,8 @@ class Bridge:
                     'ProgrammingModel': {'href': '/programmingmodel/200'},
                     'Parent': {'href': '/area/9'},
                     'IsProgrammed': True,
-                    'Category': {'Type': 'LivingRoom', 'SubType': 'Bright'}}]}})
+                    'Category': {'Type': 'LivingRoom', 'SubType': 'Bright'}
+                }]}})
         requested_zones = []
         for _ in range(0, 2):
             value = yield from wait(writer.queue.get())


### PR DESCRIPTION
New engraved picos (released with RadioRA2 Select but compatible with Caseta) operate by creating virtual buttons/scenes that they trigger (this allows them to control different sets of lights with different buttons, rather than requiring each button in a pico to control the same set of lights).

Those scenes do not have a `Name` attribute, causing scene detection to crash pylutron-caseta for any system that has these devices.  This will skip assignment of those.