### PR TITLE
treat OSError like ConnectionError

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -272,7 +272,10 @@ class Smartbridge:
                     _LOG.debug('received LEAP: %s', received)
                     if received is not None:
                         self._handle_response(received)
-                except (ValueError, ConnectionError, asyncio.TimeoutError):
+                # ignore OSError too.
+                # sometimes you get OSError instead of ConnectionError.
+                except (ValueError, ConnectionError, OSError,
+                        asyncio.TimeoutError):
                     _LOG.warning("reconnecting", exc_info=1)
                     await asyncio.sleep(RECONNECT_DELAY)
         except asyncio.CancelledError:


### PR DESCRIPTION
Sometimes Python incorrectly reports OSError "No route to host" which does not derive from ConnectionError when you fail to create a network connection. pylutron_caseta should continue attempting to reconnect if it gets such an error.

This just retries after any OSError. It doesn't try to figure out what OS its running on and what that error code means for the current OS.

Fixes #45 