### PR TITLE
update tools and add black

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"editor.formatOnSave": true,
 		"editor.formatOnType": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.blackPath": "/usr/local/bin/black",
 		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
 		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
 		"python.linting.flake8Path": "/usr/local/bin/flake8",

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - python: "3.5"
-      env: TOXENV=py35
-    - python: "3.6"
-      env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
-    - python: "3.7"
+    - python: "3.8"
+      env: TOXENV=py38
+    - python: "3.8"
       env: TOXENV=lint
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-sudo: false
-matrix:
+os: linux
+dist: focal
+
+jobs:
   fast_finish: true
   include:
     - python: "3.7"

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -1,22 +1,35 @@
 """An API to communicate with the Lutron Caseta Smart Bridge."""
 
-_LEAP_DEVICE_TYPES = {'light': ['WallDimmer', 'PlugInDimmer'],
-                      'switch': ['WallSwitch'],
-                      'fan': ['CasetaFanSpeedController'],
-                      'cover': ['SerenaHoneycombShade', 'SerenaRollerShade',
-                                'TriathlonHoneycombShade',
-                                'TriathlonRollerShade', 'QsWirelessShade'],
-                      'sensor': ['Pico1Button', 'Pico2Button',
-                                 'Pico2ButtonRaiseLower', 'Pico3Button',
-                                 'Pico3ButtonRaiseLower', 'Pico4Button',
-                                 'Pico4ButtonScene', 'Pico4ButtonZone',
-                                 'Pico4Button2Group', 'FourGroupRemote']}
+_LEAP_DEVICE_TYPES = {
+    "light": ["WallDimmer", "PlugInDimmer"],
+    "switch": ["WallSwitch"],
+    "fan": ["CasetaFanSpeedController"],
+    "cover": [
+        "SerenaHoneycombShade",
+        "SerenaRollerShade",
+        "TriathlonHoneycombShade",
+        "TriathlonRollerShade",
+        "QsWirelessShade",
+    ],
+    "sensor": [
+        "Pico1Button",
+        "Pico2Button",
+        "Pico2ButtonRaiseLower",
+        "Pico3Button",
+        "Pico3ButtonRaiseLower",
+        "Pico4Button",
+        "Pico4ButtonScene",
+        "Pico4ButtonZone",
+        "Pico4Button2Group",
+        "FourGroupRemote",
+    ],
+}
 
-FAN_OFF = 'Off'
-FAN_LOW = 'Low'
-FAN_MEDIUM = 'Medium'
-FAN_MEDIUM_HIGH = 'MediumHigh'
-FAN_HIGH = 'High'
+FAN_OFF = "Off"
+FAN_LOW = "Low"
+FAN_MEDIUM = "Medium"
+FAN_MEDIUM_HIGH = "MediumHigh"
+FAN_HIGH = "High"
 
 OCCUPANCY_GROUP_OCCUPIED = "Occupied"
 OCCUPANCY_GROUP_UNOCCUPIED = "Unoccupied"

--- a/pylutron_caseta/leap.py
+++ b/pylutron_caseta/leap.py
@@ -9,11 +9,9 @@ _LOG = logging.getLogger(__name__)
 _DEFAULT_LIMIT = 2 ** 16
 
 
-async def open_connection(host=None, port=None, *,
-                          limit=_DEFAULT_LIMIT, **kwds):
+async def open_connection(host=None, port=None, *, limit=_DEFAULT_LIMIT, **kwds):
     """Open a stream and wrap it with LEAP."""
-    connection = await asyncio.open_connection(host, port,
-                                               limit=limit, **kwds)
+    connection = await asyncio.open_connection(host, port, limit=limit, **kwds)
     return LeapReader(connection[0]), LeapWriter(connection[1])
 
 
@@ -38,12 +36,12 @@ class LeapReader:
         """
         received = await self._reader.readline()
 
-        if received == b'':
+        if received == b"":
             return None
-        _LOG.debug('received %s', received)
+        _LOG.debug("received %s", received)
 
         try:
-            return json.loads(received.decode('UTF-8'))
+            return json.loads(received.decode("UTF-8"))
         except ValueError as err:
             _LOG.error("Invalid LEAP response: %s", received)
             self._reader.set_exception(err)
@@ -58,9 +56,9 @@ class LeapReader:
         """
         while True:
             received = await self.read()
-            if received.get('CommuniqueType', None) == communique_type:
+            if received.get("CommuniqueType", None) == communique_type:
                 return received
-            _LOG.info('Ignoring message %s', received)
+            _LOG.info("Ignoring message %s", received)
 
     def at_eof(self):
         """Return `True` if the underlying stream is at EOF."""
@@ -84,16 +82,16 @@ class LeapWriter:
 
     def write(self, obj):
         """Write a single object."""
-        text = json.dumps(obj).encode('UTF-8')
-        _LOG.debug('sending %s', text)
-        self._writer.write(text + b'\r\n')
+        text = json.dumps(obj).encode("UTF-8")
+        _LOG.debug("sending %s", text)
+        self._writer.write(text + b"\r\n")
 
     def write_eof(self):
         """Write EOF to the underlying stream."""
         self._writer.write_eof()
 
 
-_HREFRE = re.compile(r'/(?:\D+)/(\d+)(?:\/\D+)?')
+_HREFRE = re.compile(r"/(?:\D+)/(\d+)(?:\/\D+)?")
 
 
 def id_from_href(href):
@@ -103,5 +101,5 @@ def id_from_href(href):
     """
     try:
         return _HREFRE.match(href).group(1)
-    except IndexError:
-        raise ValueError("Cannot find ID from href {}".format(href))
+    except IndexError as ex:
+        raise ValueError("Cannot find ID from href {}".format(href)) from ex

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import socket
 import ssl
+
 try:
     from asyncio import get_running_loop as get_loop
 except ImportError:
@@ -52,8 +53,7 @@ class Smartbridge:
         self._monitor_task = get_loop().create_task(self._monitor())
 
     @classmethod
-    def create_tls(cls, hostname, keyfile, certfile, ca_certs,
-                   port=LEAP_PORT):
+    def create_tls(cls, hostname, keyfile, certfile, ca_certs, port=LEAP_PORT):
         """Initialize the Smart Bridge using TLS over IPv4."""
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         ssl_context.load_verify_locations(ca_certs)
@@ -61,12 +61,15 @@ class Smartbridge:
         ssl_context.verify_mode = ssl.CERT_REQUIRED
 
         async def _connect():
-            res = await open_connection(hostname,
-                                        port,
-                                        server_hostname='',
-                                        ssl=ssl_context,
-                                        family=socket.AF_INET)
+            res = await open_connection(
+                hostname,
+                port,
+                server_hostname="",
+                ssl=ssl_context,
+                family=socket.AF_INET,
+            )
             return res
+
         return cls(_connect)
 
     def add_subscriber(self, device_id, callback_):
@@ -106,7 +109,7 @@ class Smartbridge:
 
         # loop over all devices and check their type
         for device_id in self.devices:
-            if self.devices[device_id]['type'] in _LEAP_DEVICE_TYPES[domain]:
+            if self.devices[device_id]["type"] in _LEAP_DEVICE_TYPES[domain]:
                 devs.append(self.devices[device_id])
         return devs
 
@@ -118,7 +121,7 @@ class Smartbridge:
         """
         devs = []
         for device_id in self.devices:
-            if self.devices[device_id]['type'] == type_:
+            if self.devices[device_id]["type"] == type_:
                 devs.append(self.devices[device_id])
         return devs
 
@@ -132,7 +135,7 @@ class Smartbridge:
         :raises KeyError: if the zone id is not present
         """
         for device in self.devices.values():
-            if zone_id == device.get('zone'):
+            if zone_id == device.get("zone"):
                 return device
         raise KeyError("No device associated with zone {}".format(zone_id))
 
@@ -144,7 +147,7 @@ class Smartbridge:
         """
         devs = []
         for device_id in self.devices:
-            if self.devices[device_id]['type'] in types:
+            if self.devices[device_id]["type"] in types:
                 devs.append(self.devices[device_id])
         return devs
 
@@ -179,8 +182,10 @@ class Smartbridge:
         :param device_id: device id, e.g. 5
         :returns True if level is greater than 0 level, False otherwise
         """
-        return (self.devices[device_id]['current_state'] > 0 or
-                (self.devices[device_id]['fan_speed'] or FAN_OFF) != FAN_OFF)
+        return (
+            self.devices[device_id]["current_state"] > 0
+            or (self.devices[device_id]["fan_speed"] or FAN_OFF) != FAN_OFF
+        )
 
     def set_value(self, device_id, value):
         """
@@ -197,22 +202,23 @@ class Smartbridge:
                 "Body": {
                     "Command": {
                         "CommandType": "GoToLevel",
-                        "Parameter": [{"Type": "Level", "Value": value}]}}}
+                        "Parameter": [{"Type": "Level", "Value": value}],
+                    }
+                },
+            }
             self._writer.write(cmd)
 
     def _send_zone_create_request(self, device_id, command):
         zone_id = self._get_zone_id(device_id)
         if not zone_id:
             return
-        self._writer.write({
-            "CommuniqueType": "CreateRequest",
-            "Header": {"Url": "/zone/%s/commandprocessor" % zone_id},
-            "Body": {
-                "Command": {
-                    "CommandType": command
-                }
+        self._writer.write(
+            {
+                "CommuniqueType": "CreateRequest",
+                "Header": {"Url": "/zone/%s/commandprocessor" % zone_id},
+                "Body": {"Command": {"CommandType": command}},
             }
-        })
+        )
 
     def stop_cover(self, device_id):
         """Will stop a cover."""
@@ -224,7 +230,7 @@ class Smartbridge:
         # If set_value is called, we get an optimistic callback right
         # away with the value, if we use Raise we have to set it
         # as one won't come unless Stop is called or something goes wrong.
-        self.devices[device_id]['current_state'] = 100
+        self.devices[device_id]["current_state"] = 100
 
     def lower_cover(self, device_id):
         """Will lower a cover."""
@@ -232,7 +238,7 @@ class Smartbridge:
         # If set_value is called, we get an optimistic callback right
         # away with the value, if we use Lower we have to set it
         # as one won't come unless Stop is called or something goes wrong.
-        self.devices[device_id]['current_state'] = 0
+        self.devices[device_id]["current_state"] = 0
 
     def set_fan(self, device_id, value):
         """
@@ -250,7 +256,10 @@ class Smartbridge:
                 "Body": {
                     "Command": {
                         "CommandType": "GoToFanSpeed",
-                        "FanSpeedParameters": {"FanSpeed": value}}}}
+                        "FanSpeedParameters": {"FanSpeed": value},
+                    }
+                },
+            }
             self._writer.write(cmd)
 
     def turn_on(self, device_id):
@@ -278,9 +287,9 @@ class Smartbridge:
         if scene_id in self.scenes:
             cmd = {
                 "CommuniqueType": "CreateRequest",
-                "Header": {
-                    "Url": "/virtualbutton/%s/commandprocessor" % scene_id},
-                "Body": {"Command": {"CommandType": "PressAndRelease"}}}
+                "Header": {"Url": "/virtualbutton/%s/commandprocessor" % scene_id},
+                "Body": {"Command": {"CommandType": "PressAndRelease"}},
+            }
             self._writer.write(cmd)
 
     def _get_zone_id(self, device_id):
@@ -289,7 +298,7 @@ class Smartbridge:
 
         :param device_id: device id for which to retrieve a zone id
         """
-        return self.devices[device_id].get('zone')
+        return self.devices[device_id].get("zone")
 
     def _send_command(self, cmd):
         """Send a command to the bridge."""
@@ -300,22 +309,20 @@ class Smartbridge:
         try:
             while True:
                 try:
-                    await asyncio.wait_for(self._login(),
-                                           timeout=CONNECT_TIMEOUT)
+                    await asyncio.wait_for(self._login(), timeout=CONNECT_TIMEOUT)
                     received = await self._reader.read()
-                    _LOG.debug('received LEAP: %s', received)
+                    _LOG.debug("received LEAP: %s", received)
                     if received is not None:
                         self._handle_response(received)
                 # ignore OSError too.
                 # sometimes you get OSError instead of ConnectionError.
-                except (ValueError, ConnectionError, OSError,
-                        asyncio.TimeoutError):
+                except (ValueError, ConnectionError, OSError, asyncio.TimeoutError):
                     _LOG.warning("reconnecting", exc_info=1)
                     await asyncio.sleep(RECONNECT_DELAY)
         except asyncio.CancelledError:
             pass
         except Exception:
-            _LOG.critical('monitor loop has exited', exc_info=1)
+            _LOG.critical("monitor loop has exited", exc_info=1)
             raise
 
     def _handle_response(self, resp_json):
@@ -328,41 +335,43 @@ class Smartbridge:
 
         :param resp_json: full JSON response from the LEAP connection
         """
-        comm_type = resp_json['CommuniqueType']
-        if comm_type == 'ReadResponse':
+        comm_type = resp_json["CommuniqueType"]
+        if comm_type == "ReadResponse":
             self._handle_read_response(resp_json)
 
     def _handle_one_zone_status(self, resp_json):
-        body = resp_json['Body']
-        status = body['ZoneStatus']
-        zone = id_from_href(status['Zone']['href'])
-        level = status.get('Level', -1)
-        fan_speed = status.get('FanSpeed', None)
-        _LOG.debug('zone=%s level=%s', zone, level)
+        body = resp_json["Body"]
+        status = body["ZoneStatus"]
+        zone = id_from_href(status["Zone"]["href"])
+        level = status.get("Level", -1)
+        fan_speed = status.get("FanSpeed", None)
+        _LOG.debug("zone=%s level=%s", zone, level)
         device = self.get_device_by_zone_id(zone)
-        device['current_state'] = level
-        device['fan_speed'] = fan_speed
-        if device['device_id'] in self._subscribers:
-            self._subscribers[device['device_id']]()
+        device["current_state"] = level
+        device["fan_speed"] = fan_speed
+        if device["device_id"] in self._subscribers:
+            self._subscribers[device["device_id"]]()
 
     def _handle_one_ping_response(self, _):
         self._got_ping.set()
 
     def _handle_occupancy_group_status(self, resp_json):
         _LOG.debug("Handling occupancy group status: %s", resp_json)
-        statuses = resp_json.get('Body', {}).get('OccupancyGroupStatuses', {})
+        statuses = resp_json.get("Body", {}).get("OccupancyGroupStatuses", {})
         for status in statuses:
-            occgroup_id = id_from_href(status['OccupancyGroup']['href'])
-            ostat = status['OccupancyStatus']
+            occgroup_id = id_from_href(status["OccupancyGroup"]["href"])
+            ostat = status["OccupancyStatus"]
             if occgroup_id not in self.occupancy_groups:
                 if ostat != OCCUPANCY_GROUP_UNKNOWN:
-                    _LOG.warning("Occupancy group %s has a status but no "
-                                 "sensors", occgroup_id)
+                    _LOG.warning(
+                        "Occupancy group %s has a status but no " "sensors", occgroup_id
+                    )
                 continue
             if ostat == OCCUPANCY_GROUP_UNKNOWN:
-                _LOG.warning("Occupancy group %s has sensors but no status",
-                             occgroup_id)
-            self.occupancy_groups[occgroup_id]['status'] = ostat
+                _LOG.warning(
+                    "Occupancy group %s has sensors but no status", occgroup_id
+                )
+            self.occupancy_groups[occgroup_id]["status"] = ostat
             # Notify any subscribers of the change to occupancy status
             if occgroup_id in self._occupancy_subscribers:
                 self._occupancy_subscribers[occgroup_id]()
@@ -374,7 +383,7 @@ class Smartbridge:
     )
 
     def _handle_read_response(self, resp_json):
-        body_type = resp_json.get('Header', {}).get('MessageBodyType')
+        body_type = resp_json.get("Header", {}).get("MessageBodyType")
         if body_type in self._read_response_handler_callbacks:
             self._read_response_handler_callbacks[body_type](self, resp_json)
 
@@ -382,9 +391,11 @@ class Smartbridge:
         """Connect and login to the Smart Bridge LEAP server using SSL."""
         async with self._login_lock:
             if self._reader is not None and self._writer is not None:
-                if (self.logged_in and
-                        self._reader.exception() is None and
-                        not self._reader.at_eof()):
+                if (
+                    self.logged_in
+                    and self._reader.exception() is None
+                    and not self._reader.at_eof()
+                ):
                     return
                 self._writer.abort()
                 self._reader = self._writer = None
@@ -400,11 +411,12 @@ class Smartbridge:
             await self._load_occupancy_groups()
             await self._subscribe_to_occupancy_groups()
             for device in self.devices.values():
-                if device.get('zone') is not None:
+                if device.get("zone") is not None:
                     _LOG.debug("Requesting zone information from %s", device)
                     cmd = {
                         "CommuniqueType": "ReadRequest",
-                        "Header": {"Url": "/zone/%s/status" % device['zone']}}
+                        "Header": {"Url": "/zone/%s/status" % device["zone"]},
+                    }
                     self._writer.write(cmd)
             self._ping_task = get_loop().create_task(self._ping())
             self.logged_in = True
@@ -417,9 +429,12 @@ class Smartbridge:
                 while True:
                     await asyncio.sleep(PING_INTERVAL)
                     self._got_ping.clear()
-                    writer.write({
-                        "CommuniqueType": "ReadRequest",
-                        "Header": {"Url": "/server/1/status/ping"}})
+                    writer.write(
+                        {
+                            "CommuniqueType": "ReadRequest",
+                            "Header": {"Url": "/server/1/status/ping"},
+                        }
+                    )
                     await asyncio.wait_for(self._got_ping.wait(), PING_DELAY)
             except asyncio.TimeoutError:
                 _LOG.warning("ping was not answered. closing connection.")
@@ -437,27 +452,27 @@ class Smartbridge:
     async def _load_devices(self):
         """Load the device list from the SSL LEAP server interface."""
         _LOG.debug("Loading devices")
-        self._writer.write({
-            "CommuniqueType": "ReadRequest", "Header": {"Url": "/device"}})
+        self._writer.write(
+            {"CommuniqueType": "ReadRequest", "Header": {"Url": "/device"}}
+        )
         device_json = await self._reader.wait_for("ReadResponse")
-        for device in device_json['Body']['Devices']:
+        for device in device_json["Body"]["Devices"]:
             _LOG.debug(device)
-            device_id = id_from_href(device['href'])
+            device_id = id_from_href(device["href"])
             device_zone = None
-            if 'LocalZones' in device:
-                device_zone = id_from_href(device['LocalZones'][0]['href'])
-            device_name = '_'.join(device['FullyQualifiedName'])
-            self.devices.setdefault(device_id, {
-                'device_id': device_id,
-                'current_state': -1,
-                'fan_speed': None
-                }).update(
-                    zone=device_zone,
-                    name=device_name,
-                    type=device['DeviceType'],
-                    model=device['ModelNumber'],
-                    serial=device['SerialNumber']
-                )
+            if "LocalZones" in device:
+                device_zone = id_from_href(device["LocalZones"][0]["href"])
+            device_name = "_".join(device["FullyQualifiedName"])
+            self.devices.setdefault(
+                device_id,
+                {"device_id": device_id, "current_state": -1, "fan_speed": None},
+            ).update(
+                zone=device_zone,
+                name=device_name,
+                type=device["DeviceType"],
+                model=device["ModelNumber"],
+                serial=device["SerialNumber"],
+            )
 
     async def _load_scenes(self):
         """
@@ -466,39 +481,34 @@ class Smartbridge:
         Scenes are known as virtual buttons in the SSL LEAP interface.
         """
         _LOG.debug("Loading scenes from the Smart Bridge")
-        self._writer.write({
-            "CommuniqueType": "ReadRequest",
-            "Header": {"Url": "/virtualbutton"}})
+        self._writer.write(
+            {"CommuniqueType": "ReadRequest", "Header": {"Url": "/virtualbutton"}}
+        )
         scene_json = await self._reader.wait_for("ReadResponse")
-        for scene in scene_json['Body']['VirtualButtons']:
+        for scene in scene_json["Body"]["VirtualButtons"]:
             _LOG.debug(scene)
             # If 'Name' is not a key in scene, then it is likely a scene pico
             # vbutton. For now, simply ignore these scenes.
-            if scene['IsProgrammed'] and 'Name' in scene:
-                scene_id = id_from_href(scene['href'])
-                scene_name = scene['Name']
-                self.scenes[scene_id] = {'scene_id': scene_id,
-                                         'name': scene_name}
+            if scene["IsProgrammed"] and "Name" in scene:
+                scene_id = id_from_href(scene["href"])
+                scene_name = scene["Name"]
+                self.scenes[scene_id] = {"scene_id": scene_id, "name": scene_name}
 
     async def _load_areas(self):
         """Load the areas from the Smart Bridge."""
         _LOG.debug("Loading areas from the Smart Bridge")
-        self._writer.write(
-            dict(CommuniqueType="ReadRequest",
-                 Header=dict(Url="/area"))
-        )
+        self._writer.write(dict(CommuniqueType="ReadRequest", Header=dict(Url="/area")))
         area_json = await self._reader.wait_for("ReadResponse")
         for area in area_json["Body"]["Areas"]:
-            area_id = id_from_href(area['href'])
+            area_id = id_from_href(area["href"])
             # We currently only need the name, so just load that
-            self.areas[area_id] = dict(name=area['Name'])
+            self.areas[area_id] = dict(name=area["Name"])
 
     async def _load_occupancy_groups(self):
         """Load the occupancy groups from the Smart Bridge."""
         _LOG.debug("Loading occupancy groups from the Smart Bridge")
         self._writer.write(
-            dict(CommuniqueType="ReadRequest",
-                 Header=dict(Url="/occupancygroup"))
+            dict(CommuniqueType="ReadRequest", Header=dict(Url="/occupancygroup"))
         )
         occgroup_json = await self._reader.wait_for("ReadResponse")
         occgroups = occgroup_json.get("Body", {}).get("OccupancyGroups", {})
@@ -508,26 +518,35 @@ class Smartbridge:
     def _process_occupancy_group(self, occgroup):
         """Process occupancy group."""
         occgroup_id = id_from_href(occgroup["href"])
-        if not occgroup.get('AssociatedSensors'):
-            _LOG.debug("No sensors associated with %s", occgroup['href'])
+        if not occgroup.get("AssociatedSensors"):
+            _LOG.debug("No sensors associated with %s", occgroup["href"])
             return
         _LOG.debug("Found occupancy group with sensors: %s", occgroup_id)
-        associated_areas = occgroup.get('AssociatedAreas', [])
+        associated_areas = occgroup.get("AssociatedAreas", [])
         if not associated_areas:
-            _LOG.error('No associated areas found with occupancy group '
-                       'containing sensors: %s -- skipping', occgroup_id)
+            _LOG.error(
+                "No associated areas found with occupancy group "
+                "containing sensors: %s -- skipping",
+                occgroup_id,
+            )
             return
         if len(associated_areas) > 1:
-            _LOG.warning("Occupancy group %s associated with multiple "
-                         "areas. Naming based on first area.", occgroup_id)
-        occgroup_area_id = id_from_href(associated_areas[0]['Area']['href'])
+            _LOG.warning(
+                "Occupancy group %s associated with multiple "
+                "areas. Naming based on first area.",
+                occgroup_id,
+            )
+        occgroup_area_id = id_from_href(associated_areas[0]["Area"]["href"])
         if occgroup_area_id not in self.areas:
-            _LOG.error('Unknown parent area for occupancy group %s: %s',
-                       occgroup_id, occgroup_area_id)
+            _LOG.error(
+                "Unknown parent area for occupancy group %s: %s",
+                occgroup_id,
+                occgroup_area_id,
+            )
             return
         self.occupancy_groups[occgroup_id] = dict(
             occupancy_group_id=occgroup_id,
-            name='{} Occupancy'.format(self.areas[occgroup_area_id]['name']),
+            name="{} Occupancy".format(self.areas[occgroup_area_id]["name"]),
             status=OCCUPANCY_GROUP_UNKNOWN,
         )
 
@@ -535,8 +554,10 @@ class Smartbridge:
         """Subscribe to occupancy group status updates."""
         _LOG.debug("Subscribing to occupancy group status updates")
         self._writer.write(
-            dict(CommuniqueType="SubscribeRequest",
-                 Header=dict(Url="/occupancygroup/status"))
+            dict(
+                CommuniqueType="SubscribeRequest",
+                Header=dict(Url="/occupancygroup/status"),
+            )
         )
         response = await self._reader.wait_for("SubscribeResponse")
         if response["Header"]["StatusCode"].startswith("20"):
@@ -548,12 +569,10 @@ class Smartbridge:
 
     async def close(self):
         """Disconnect from the bridge."""
-        _LOG.info('Processing Smartbridge.close() call')
-        if (self._monitor_task is not None and
-                not self._monitor_task.cancelled()):
+        _LOG.info("Processing Smartbridge.close() call")
+        if self._monitor_task is not None and not self._monitor_task.cancelled():
             self._monitor_task.cancel()
-        if (self._ping_task is not None and
-                not self._ping_task.cancelled()):
+        if self._ping_task is not None and not self._ping_task.cancelled():
             self._ping_task.cancel()
         await self._writer.drain()
         self._writer.abort()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,17 +1,14 @@
 # linters such as flake8 and pylint should be pinned, as new releases
 # make new things fail. Manually update these pins when pulling in a
 # new version
-flake8==3.7.9
-pylint==2.4.4
-mypy-lang==0.5.0
-pydocstyle==5.0.2
-coveralls~=1.8
-pytest~=3.10
-pytest-asyncio==0.10.0
-pytest-catchlog~=1.2
-pytest-cov~=2.8
-pytest-timeout~=1.3
-pytest-sugar~=0.9.2
-mock-open~=1.3
-flake8-docstrings==1.5.0
-asynctest~=0.12.4
+black==20.8b1
+flake8==3.8.3
+pylint==2.6.0
+mypy==0.782
+pydocstyle==5.1.1
+coveralls~=2.1.2
+pytest~=6.0.1
+pytest-asyncio==0.14.0
+pytest-cov~=2.10.1
+pytest-timeout~=1.4.2
+pytest-sugar~=0.9.4

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
     platforms=["Linux"],
     url="https://github.com/gurumitts/pylutron-caseta",
     download_url="https://github.com/gurumitts/pylutron-caseta",
-    packages=["pylutron_caseta"], install_requires=[]
+    packages=["pylutron_caseta"],
+    install_requires=[],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py35, py36, py37, lint, typing
+envlist = py37, lint, typing
 skip_missing_interpreters = True
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pylutron-caseta
 commands =
-     py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}
+     py.test --timeout=30 --durations=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_test.txt
 
@@ -17,13 +17,14 @@ deps =
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements_test.txt
 commands =
+     black --check .
      flake8
-     pylint pylutron_caseta
-     pydocstyle pylutron_caseta tests
+     pylint pylutron_caseta tests
+     pydocstyle
 
 [testenv:typing]
 basepython = python3
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --silent-imports pylutron_caseta
+         mypy pylutron_caseta tests

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,6 @@ deps =
 commands =
      black --check .
      flake8
-     pylint pylutron_caseta tests/*.py
+     pylint pylutron_caseta tests/test_leap.py tests/test_smartbridge.py
      pydocstyle
      mypy pylutron_caseta tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, lint, typing
+envlist = py37, py38, lint
 skip_missing_interpreters = True
 
 [testenv]
@@ -21,10 +21,4 @@ commands =
      flake8
      pylint pylutron_caseta tests/*.py
      pydocstyle
-
-[testenv:typing]
-basepython = python3
-deps =
-     -r{toxinidir}/requirements_test.txt
-commands =
-         mypy pylutron_caseta tests
+     mypy pylutron_caseta tests

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 commands =
      black --check .
      flake8
-     pylint pylutron_caseta tests
+     pylint pylutron_caseta tests/*.py
      pydocstyle
 
 [testenv:typing]


### PR DESCRIPTION
All files have been reformatted and some minor linter complaints have been addressed.

Python versions 3.5 and 3.6 are no longer supported.

The only functional difference is that now when `id_from_href` raises an exception the source exception information is included.