### PR TITLE
expect tags on occupancy group updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- If the bridge does not return information about occupancy groups, pylutron_caseta will still initialize.
+- Occupancy groups are now subscribed correctly.
+
 ## [0.7.0] - 2020-10-03
 
 ### Added

--- a/pylintrc
+++ b/pylintrc
@@ -9,3 +9,7 @@ disable=
 good-names=
   i,j,k,ex,Run,_, # defaults
   T
+
+[SIMILARITIES]
+# allow more lines when using typing to allow for copied signatures
+min-similarity-lines=8


### PR DESCRIPTION
Unlike the unsolicited status updates for lights, switches, etc, the occupancy group status updates must be subscribed to, and they are sent with the same tag value that was used for the original subscription.

Related: home-assistant/core#42620