### PR TITLE
release subscriptions on disconnect

### DIFF
--- a/pylutron_caseta/leap.py
+++ b/pylutron_caseta/leap.py
@@ -168,6 +168,7 @@ class LeapProtocol:
         for request in self._in_flight_requests.values():
             request.set_exception(BridgeDisconnectedError())
         self._in_flight_requests.clear()
+        self._tagged_subscriptions.clear()
 
 
 async def open_connection(


### PR DESCRIPTION
This should not matter in general because the LeapProtocol object itself is released by SmartBridge shortly after the connection is closed.