### PR TITLE
Add SerenaTiltOnlyWoodBlind to cover types

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -14,6 +14,7 @@ _LEAP_DEVICE_TYPES = {
         "TriathlonHoneycombShade",
         "TriathlonRollerShade",
         "QsWirelessShade",
+        "SerenaTiltOnlyWoodBlind",
     ],
     "sensor": [
         "Pico1Button",


### PR DESCRIPTION
This adds support for Serena Wood Blinds that were introduced earlier this year.