### PR TITLE
use setdefault for areas and occupancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Instances in the `areas` and `occupancy_groups` dictionaries are no longer replaced during reconnection, which can cause surprise issues after a network interruption or bridge restart in consuming software such as Home Assistant. This is consistent with the `devices` dictionary.
+
 ## [0.7.1] - 2020-11-01
 
 ### Fixed

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -592,7 +592,7 @@ class Smartbridge:
         for area in area_json.Body["Areas"]:
             area_id = id_from_href(area["href"])
             # We currently only need the name, so just load that
-            self.areas[area_id] = dict(name=area["Name"])
+            self.areas.setdefault(area_id, dict(name=area["Name"]))
 
     async def _load_occupancy_groups(self):
         """Load the occupancy groups from the Smart Bridge."""
@@ -634,10 +634,14 @@ class Smartbridge:
                 occgroup_area_id,
             )
             return
-        self.occupancy_groups[occgroup_id] = dict(
-            occupancy_group_id=occgroup_id,
-            name="{} Occupancy".format(self.areas[occgroup_area_id]["name"]),
-            status=OCCUPANCY_GROUP_UNKNOWN,
+        self.occupancy_groups.setdefault(
+            occgroup_id,
+            dict(
+                occupancy_group_id=occgroup_id,
+                status=OCCUPANCY_GROUP_UNKNOWN,
+            ),
+        ).update(
+            name=f"{self.areas[occgroup_area_id]['name']} Occupancy",
         )
 
     async def _subscribe_to_occupancy_groups(self):


### PR DESCRIPTION
This should fix a problem @gmcmicken reported on #60 where his occupancy groups stop updating in Home Assistant after restarting the bridge connection.