### PR TITLE
chore: ignore python environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build/
 /caseta.key
 /dist/
 /pylutron_caseta.egg-info/
+/env/


### PR DESCRIPTION
If user just checks out the git repo and follows the instructions in the header of `get_lutron_cert.py`, they get a python environment inside their copy of the git repo. Ignoring `/env/`  protects against that.