### PR TITLE
Add support for PD-15OUT outdoor switches.

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -6,7 +6,10 @@ from .messages import Response, ResponseStatus
 
 _LEAP_DEVICE_TYPES = {
     "light": ["WallDimmer", "PlugInDimmer"],
-    "switch": ["WallSwitch"],
+    "switch": [
+        "WallSwitch",
+        "OutdoorPlugInSwitch",
+    ],
     "fan": ["CasetaFanSpeedController"],
     "cover": [
         "SerenaHoneycombShade",


### PR DESCRIPTION
The PD-15OUT connected to my smart hub identifies itself as being type `OutdoorPlugInSwitch`. This adds it to the switch domain.