### PR TITLE
add support for pico button events

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -49,6 +49,7 @@ OCCUPANCY_GROUP_UNKNOWN = "Unknown"
 BUTTON_STATUS_PRESSED = "Press"
 BUTTON_STATUS_RELEASED = "Release"
 
+
 class BridgeDisconnectedError(Exception):
     """Raised when the connection is lost while waiting for a response."""
 

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -46,6 +46,8 @@ OCCUPANCY_GROUP_OCCUPIED = "Occupied"
 OCCUPANCY_GROUP_UNOCCUPIED = "Unoccupied"
 OCCUPANCY_GROUP_UNKNOWN = "Unknown"
 
+BUTTON_STATUS_PRESSED = "Press"
+BUTTON_STATUS_RELEASED = "Release"
 
 class BridgeDisconnectedError(Exception):
     """Raised when the connection is lost while waiting for a response."""

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -18,6 +18,7 @@ from . import (
     _LEAP_DEVICE_TYPES,
     FAN_OFF,
     OCCUPANCY_GROUP_UNKNOWN,
+    BUTTON_STATUS_RELEASED,
     BridgeDisconnectedError,
     BridgeResponseError,
 )
@@ -43,6 +44,7 @@ class Smartbridge:
     def __init__(self, connect: Callable[[], LeapProtocol]):
         """Initialize the Smart Bridge."""
         self.devices: Dict[str, dict] = {}
+        self.buttons: Dict[str, dict] = {}
         self.lip_devices: Dict[int, dict] = {}
         self.scenes: Dict[str, dict] = {}
         self.occupancy_groups: Dict[str, dict] = {}
@@ -50,6 +52,7 @@ class Smartbridge:
         self._connect = connect
         self._subscribers: Dict[str, Callable[[], None]] = {}
         self._occupancy_subscribers: Dict[str, Callable[[], None]] = {}
+        self._button_subscribers: Dict[str, Callable[[], None]] = {}
         self._login_task: Optional[asyncio.Task] = None
         # Use future so we can wait before the login starts and
         # don't need to wait for "login" on reconnect.
@@ -140,9 +143,24 @@ class Smartbridge:
         """
         self._occupancy_subscribers[occupancy_group_id] = callback_
 
+    def add_button_subscriber(
+        self, button_id: str, callback_: Callable[[], None]
+    ):
+        """
+        Add a listener to be notified of button state changes.
+
+        :param button_id: button id, e.g., 2
+        :param callback_: callback to invoke
+        """
+        self._button_subscribers[button_id] = callback_
+
     def get_devices(self) -> Dict[str, dict]:
         """Will return all known devices connected to the Smart Bridge."""
         return self.devices
+
+    def get_buttons(self) -> Dict[str, dict]:
+        """Will return all known Pico buttons connected to the Smart Bridge."""
+        return self.buttons
 
     def get_devices_by_domain(self, domain: str) -> List[dict]:
         """
@@ -474,6 +492,21 @@ class Smartbridge:
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
 
+    def _handle_button_status(self, response: Response):
+        _LOG.debug("Handling button status: %s", response)
+
+        if response.Body is None:
+            return
+
+        status = response.Body["ButtonStatus"]
+        button_id = id_from_href(status["Button"]["href"])
+        button_event = status["ButtonEvent"]["EventType"]
+        if button_id in self.buttons:
+            self.buttons[button_id]["current_state"] = button_event
+            # Notify any subscribers of the change to occupancy status
+            if button_id in self._button_subscribers:
+                self._button_subscribers[button_id](button_event)
+
     def _handle_occupancy_group_status(self, response: Response):
         _LOG.debug("Handling occupancy group status: %s", response)
 
@@ -510,11 +543,13 @@ class Smartbridge:
         """Connect and login to the Smart Bridge LEAP server using SSL."""
         try:
             await self._load_devices()
+            await self._load_buttons()
             await self._load_lip_devices()
             await self._load_scenes()
             await self._load_areas()
             await self._load_occupancy_groups()
             await self._subscribe_to_occupancy_groups()
+            await self._subscribe_to_button_status()
 
             for device in self.devices.values():
                 if device.get("zone") is not None:
@@ -556,8 +591,11 @@ class Smartbridge:
             _LOG.debug(device)
             device_id = id_from_href(device["href"])
             device_zone = None
+            button_group = None
             if "LocalZones" in device:
                 device_zone = id_from_href(device["LocalZones"][0]["href"])
+            if "ButtonGroups" in device:
+                button_group = id_from_href(device["ButtonGroups"][0]["href"])
             device_name = "_".join(device["FullyQualifiedName"])
             self.devices.setdefault(
                 device_id,
@@ -565,6 +603,7 @@ class Smartbridge:
             ).update(
                 zone=device_zone,
                 name=device_name,
+                buttongroup=button_group,
                 type=device["DeviceType"],
                 model=device["ModelNumber"],
                 serial=device["SerialNumber"],
@@ -603,6 +642,26 @@ class Smartbridge:
                 scene_id = id_from_href(scene["href"])
                 scene_name = scene["Name"]
                 self.scenes[scene_id] = {"scene_id": scene_id, "name": scene_name}
+
+    async def _load_buttons(self):
+        """Load Pico button groups and button mappings"""
+        _LOG.debug("Loading buttons for Pico Button Groups")
+        button_json = await self._request("ReadRequest", "/button")
+        button_devices = {v["buttongroup"]: v for (k, v) in self.devices.items() if v["buttongroup"] is not None}
+        for button in button_json.Body["Buttons"]:
+            button_device = button_devices[id_from_href(button["Parent"]["href"])]
+            button_id = id_from_href(button["href"])
+            button_number = button["ButtonNumber"]
+            pico_name = button_device["name"]
+            self.buttons.setdefault(
+                button_id,
+                {"device_id": button_id, "current_state": BUTTON_STATUS_RELEASED,  "button_number": button_number},
+            ).update(
+                name=pico_name,
+                type=button_device["type"],
+                model=button_device["model"],
+                serial=button_device["serial"],
+            )
 
     async def _load_areas(self):
         """Load the areas from the Smart Bridge."""
@@ -662,6 +721,21 @@ class Smartbridge:
         ).update(
             name=f"{self.areas[occgroup_area_id]['name']} Occupancy",
         )
+
+    async def _subscribe_to_button_status(self):
+        """Subscribe to pico button status updates."""
+        _LOG.debug("Subscribing to pico button status updates")
+        self.buttons
+        try:
+            for button in self.buttons:
+                response, _ = await self._subscribe(
+                   "/button/"+str(button)+"/status/event", self._handle_button_status
+                )
+                _LOG.debug("Subscribed to device status")
+                self._handle_button_status(response)
+        except BridgeResponseError as ex:
+            _LOG.error("Failed device status subscription: %s", ex.response)
+            return
 
     async def _subscribe_to_occupancy_groups(self):
         """Subscribe to occupancy group status updates."""

--- a/tests/responses/buttons.json
+++ b/tests/responses/buttons.json
@@ -1,0 +1,23 @@
+{
+    "CommuniqueType": "ReadResponse",
+    "Header": {
+        "MessageBodyType": "MultipleButtonDefinition",
+        "StatusCode": "200 OK",
+        "Url": "/button"
+    },
+    "Body": {
+        "Buttons": [
+            {
+                "href": "/button/101",
+                "ButtonNumber": 0,
+                "ProgrammingModel": {
+                    "href": "/programmingmodel/127"
+                },
+                "Parent": {
+                    "href": "/buttongroup/2"
+                },
+                "Name": "Button 1"
+            }
+        ]
+    }
+}

--- a/tests/responses/buttonsubscribe.json
+++ b/tests/responses/buttonsubscribe.json
@@ -1,0 +1,7 @@
+{
+    "CommuniqueType": "SubscribeResponse",
+    "Header": {
+        "StatusCode": "204 NoContent",
+        "Url": "/button/101/status/event"
+    }
+}

--- a/tests/responses/devices.json
+++ b/tests/responses/devices.json
@@ -166,17 +166,66 @@
             {
                 "href": "/device/7",
                 "Name": "Living Shade 3",
-                "FullyQualifiedName": ["Living Room", "Living Shade 3"],
+                "FullyQualifiedName": [
+                    "Living Room",
+                    "Living Shade 3"
+                ],
                 "Parent": {
                     "href": "/project"
                 },
                 "SerialNumber": 1234,
                 "ModelNumber": "QSYC-J-RCVR",
                 "DeviceType": "QsWirelessShade",
-                "LocalZones": [{"href": "/zone/6"}],
-                "AssociatedArea": {"href": "/area/4"},
-                "LinkNodes": [{"href": "/device/10/linknode/9"}],
-                "DeviceRules": [{"href": "/devicerule/10"}]
+                "LocalZones": [
+                    {
+                        "href": "/zone/6"
+                    }
+                ],
+                "AssociatedArea": {
+                    "href": "/area/4"
+                },
+                "LinkNodes": [
+                    {
+                        "href": "/device/10/linknode/9"
+                    }
+                ],
+                "DeviceRules": [
+                    {
+                        "href": "/devicerule/10"
+                    }
+                ]
+            },
+            {
+                "href": "/device/8",
+                "Name": "Pico",
+                "FullyQualifiedName": [
+                    "Master Bedroom",
+                    "Pico"
+                ],
+                "Parent": {
+                    "href": "/project"
+                },
+                "SerialNumber": 4321,
+                "ModelNumber": "PJ2-3BRL-GXX-X01",
+                "DeviceType": "Pico3ButtonRaiseLower",
+                "ButtonGroups": [
+                    {
+                        "href": "/buttongroup/2"
+                    }
+                ],
+                "AssociatedArea": {
+                    "href": "/area/2"
+                },
+                "LinkNodes": [
+                    {
+                        "href": "/device/3/linknode/3"
+                    }
+                ],
+                "DeviceRules": [
+                    {
+                        "href": "/devicerule/25"
+                    }
+                ]
             }
         ]
     }

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -25,6 +25,7 @@ from pylutron_caseta import (
     FAN_MEDIUM,
     OCCUPANCY_GROUP_OCCUPIED,
     OCCUPANCY_GROUP_UNOCCUPIED,
+    BUTTON_STATUS_PRESSED,
     BridgeDisconnectedError,
 )
 
@@ -139,6 +140,9 @@ class Bridge:
         self.occupancy_group_subscription_data_result = response_from_json_file(
             "occupancygroupsubscribe.json"
         )
+        self.button_subscription_data_result = response_from_json_file(
+            "buttonsubscribe.json"
+        )
 
         async def fake_connect():
             """Open a fake LEAP connection for the test."""
@@ -180,36 +184,50 @@ class Bridge:
         response.set_result(response_from_json_file("devices.json"))
         leap.requests.task_done()
 
-        # Second message should be read request on /server/2/id
+        # Second message should be read request on /button
+        request, response = await wait(leap.requests.get())
+        assert request == Request(communique_type="ReadRequest", url="/button")
+        response.set_result(response_from_json_file("buttons.json"))
+        leap.requests.task_done()
+
+        # Third message should be read request on /server/2/id
         request, response = await wait(leap.requests.get())
         assert request == Request(communique_type="ReadRequest", url="/server/2/id")
         response.set_result(response_from_json_file("lip.json"))
         leap.requests.task_done()
 
-        # Third message should be read request on /virtualbutton
+        # Fourth message should be read request on /virtualbutton
         request, response = await wait(leap.requests.get())
         assert request == Request(communique_type="ReadRequest", url="/virtualbutton")
         response.set_result(response_from_json_file("scenes.json"))
         leap.requests.task_done()
 
-        # Forth message should be read request on /areas
+        # Fifth message should be read request on /areas
         request, response = await wait(leap.requests.get())
         assert request == Request(communique_type="ReadRequest", url="/area")
         response.set_result(response_from_json_file("areas.json"))
         leap.requests.task_done()
 
-        # Fifth message should be read request on /occupancygroup
+        # Sixth message should be read request on /occupancygroup
         request, response = await wait(leap.requests.get())
         assert request == Request(communique_type="ReadRequest", url="/occupancygroup")
         response.set_result(self.occupancy_group_list_result)
         leap.requests.task_done()
 
-        # Sixth message should be subscribe request on /occupancygroup/status
+        # Seventh message should be subscribe request on /occupancygroup/status
         request, response = await wait(leap.requests.get())
         assert request == Request(
             communique_type="SubscribeRequest", url="/occupancygroup/status"
         )
         response.set_result(self.occupancy_group_subscription_data_result)
+        leap.requests.task_done()
+
+        # Eighth message should be subscribe request on /button/101/status/event
+        request, response = await wait(leap.requests.get())
+        assert request == Request(
+            communique_type="SubscribeRequest", url="/button/101/status/event"
+        )
+        response.set_result(self.button_subscription_data_result)
         leap.requests.task_done()
 
         # Finally, we should check the zone status on each zone
@@ -325,6 +343,7 @@ async def test_device_list(bridge: Bridge):
             "fan_speed": None,
             "model": "L-BDG2-WH",
             "serial": 1234,
+            "buttongroup": None,
         },
         "2": {
             "device_id": "2",
@@ -335,6 +354,7 @@ async def test_device_list(bridge: Bridge):
             "serial": 2345,
             "current_state": 0,
             "fan_speed": None,
+            "buttongroup": None,
         },
         "3": {
             "device_id": "3",
@@ -345,6 +365,7 @@ async def test_device_list(bridge: Bridge):
             "serial": 3456,
             "current_state": 0,
             "fan_speed": None,
+            "buttongroup": None,
         },
         "4": {
             "device_id": "4",
@@ -355,6 +376,7 @@ async def test_device_list(bridge: Bridge):
             "current_state": -1,
             "fan_speed": None,
             "zone": None,
+            "buttongroup": None,
         },
         "5": {
             "device_id": "5",
@@ -365,6 +387,7 @@ async def test_device_list(bridge: Bridge):
             "current_state": -1,
             "fan_speed": None,
             "zone": None,
+            "buttongroup": None,
         },
         "6": {
             "device_id": "6",
@@ -375,6 +398,7 @@ async def test_device_list(bridge: Bridge):
             "current_state": -1,
             "fan_speed": None,
             "zone": None,
+            "buttongroup": None,
         },
         "7": {
             "device_id": "7",
@@ -385,6 +409,18 @@ async def test_device_list(bridge: Bridge):
             "current_state": 0,
             "fan_speed": None,
             "zone": "6",
+            "buttongroup": None,
+        },
+        "8": {
+            "device_id": "8",
+            "name": "Master Bedroom_Pico",
+            "type": "Pico3ButtonRaiseLower",
+            "model": "PJ2-3BRL-GXX-X01",
+            "serial": 4321,
+            "current_state": -1,
+            "fan_speed": None,
+            "buttongroup": "2",
+            "zone": None,
         },
     }
 
@@ -607,6 +643,59 @@ async def test_occupancy_group_status_change_notification(bridge: Bridge):
                         "OccupancyStatus": "Unoccupied",
                     }
                 ]
+            },
+        )
+    )
+    assert notified
+
+
+@pytest.mark.asyncio
+async def test_button_status_change(bridge: Bridge):
+    """Test that the status is updated when Pico button is pressed."""
+    bridge.leap.send_to_subscribers(
+        Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneButtonStatusEvent",
+                StatusCode=ResponseStatus(200, "OK"),
+                Url="/button/101/status/event",
+            ),
+            Body={
+                "ButtonStatus": {
+                    "Button": {"href": "/button/101"},
+                    "ButtonEvent": {"EventType": "Press"},
+                }
+            },
+        )
+    )
+    new_status = bridge.target.buttons["101"]["current_state"]
+    assert new_status == BUTTON_STATUS_PRESSED
+
+
+@pytest.mark.asyncio
+async def test_button_status_change_notification(bridge: Bridge):
+    """Test that button status changes send notifications."""
+    notified = False
+
+    def notify(status):
+        assert status == BUTTON_STATUS_PRESSED
+        nonlocal notified
+        notified = True
+
+    bridge.target.add_button_subscriber("101", notify)
+    bridge.leap.send_to_subscribers(
+        Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneButtonStatusEvent",
+                StatusCode=ResponseStatus(200, "OK"),
+                Url="/button/101/status/event",
+            ),
+            Body={
+                "ButtonStatus": {
+                    "Button": {"href": "/button/101"},
+                    "ButtonEvent": {"EventType": "Press"},
+                }
             },
         )
     )


### PR DESCRIPTION
This code adds the ability to subscribe to Pico button events using LEAP.

A ReadRequest to /device will have some Pico devices. Each Pico will have a ButtonGroups tag with a buttongroup href and ID.  

A ReadRequest to /button will return a series of Buttons tag linked to the above button group. Each of these is a button on the Pico.  

As an example, a Pico device can have buttongroup 2, and that buttongroup can have buttons 103-107. 

To subscribe to event notifications, send a SubscribeRequest for each button ID. For 103, for example, you’d send the SubscribeRequest with the URL /button/103/status/event

Whenever you press or release that Pico button, you’ll get a ButtonStatus body with a ButtonEvent, and the EventType of “Press” or “Release”.

This code finds any devices with buttongroups, gets the list of buttons, and subscribes to events from those buttons. Some new objects are added to retrieve buttons, subscribe to events from those buttons, and to handle response messages.

