### PR TITLE
Pairing: Manually delete temporary files on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `async_pair` works on Windows.
+
 ## [0.13.1] - 2022-02-01
 
 ### Fixed

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -236,4 +236,3 @@ def _generate_signed_ssl_context(key_bytes_pem, cert_pem, ca_pem):
                 os.remove(cert_temp_file.name)
 
             return signed_ssl_context
-            

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -202,12 +202,12 @@ def _generate_csr_with_ssl_context():
 
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
                 ssl_context.load_verify_locations(cadata=LAP_CA_PEM)
-                lap_key_temp_file.close()
                 ssl_context.load_cert_chain(lap_cert_temp_file.name, lap_key_temp_file.name)
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
 
                 return csr, key_bytes_pem, ssl_context
             finally:
+                lap_key_temp_file.close()
                 lap_cert_temp_file.close()
                 os.remove(lap_key_temp_file.name)
                 os.remove(lap_cert_temp_file.name)

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -6,6 +6,7 @@ import logging
 import socket
 import ssl
 import tempfile
+import os
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -28,7 +28,6 @@ PAIR_KEY = "key"
 PAIR_CERT = "cert"
 PAIR_CA = "ca"
 PAIR_VERSION = "version"
-IS_WINDOWS = os.name == "nt"
 
 class JsonSocket:
     """A socket that reads and writes json objects."""
@@ -188,31 +187,30 @@ async def _async_verify_certificate(server_addr, signed_ssl_context):
 
 
 def _generate_csr_with_ssl_context():
-    with tempfile.NamedTemporaryFile(delete=not IS_WINDOWS) as lap_cert_temp_file:
-        with tempfile.NamedTemporaryFile(delete=not IS_WINDOWS) as lap_key_temp_file:
+    with tempfile.NamedTemporaryFile(delete=False) as lap_cert_temp_file:
+        with tempfile.NamedTemporaryFile(delete=False) as lap_key_temp_file:
+            try:
+                private_key = _generate_private_key()
+                key_bytes_pem = _convert_private_key_to_pem(private_key)
 
-            private_key = _generate_private_key()
-            key_bytes_pem = _convert_private_key_to_pem(private_key)
+                csr = _generate_csr(private_key)
 
-            csr = _generate_csr(private_key)
+                lap_cert_temp_file.write(LAP_CERT_PEM.encode("ASCII"))
+                lap_cert_temp_file.flush()
+                lap_key_temp_file.write(LAP_KEY_PEM.encode("ASCII"))
+                lap_key_temp_file.flush()
 
-            lap_cert_temp_file.write(LAP_CERT_PEM.encode("ASCII"))
-            lap_cert_temp_file.flush()
-            lap_key_temp_file.write(LAP_KEY_PEM.encode("ASCII"))
-            lap_key_temp_file.flush()
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+                ssl_context.load_verify_locations(cadata=LAP_CA_PEM)
+                ssl_context.load_cert_chain(lap_cert_temp_file.name, lap_key_temp_file.name)
+                ssl_context.verify_mode = ssl.CERT_REQUIRED
 
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-            ssl_context.load_verify_locations(cadata=LAP_CA_PEM)
-            ssl_context.load_cert_chain(lap_cert_temp_file.name, lap_key_temp_file.name)
-            ssl_context.verify_mode = ssl.CERT_REQUIRED
-            
-            if (IS_WINDOWS):
+                return csr, key_bytes_pem, ssl_context
+            finally:
                 lap_key_temp_file.close()
                 lap_cert_temp_file.close()
                 os.remove(lap_key_temp_file.name)
                 os.remove(lap_cert_temp_file.name)
-
-            return csr, key_bytes_pem, ssl_context
 
 
 def _generate_signed_ssl_context(key_bytes_pem, cert_pem, ca_pem):
@@ -221,18 +219,16 @@ def _generate_signed_ssl_context(key_bytes_pem, cert_pem, ca_pem):
         key_temp_file.flush()
 
         with tempfile.NamedTemporaryFile(delete=False) as cert_temp_file:
-            cert_temp_file.write(cert_pem.encode("ASCII"))
-            cert_temp_file.flush()
+            try:
+                cert_temp_file.write(cert_pem.encode("ASCII"))
+                cert_temp_file.flush()
 
-            signed_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-            signed_ssl_context.load_verify_locations(cadata=ca_pem)
-            signed_ssl_context.load_cert_chain(cert_temp_file.name, key_temp_file.name)
-            signed_ssl_context.verify_mode = ssl.CERT_REQUIRED
+                signed_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+                signed_ssl_context.load_verify_locations(cadata=ca_pem)
+                signed_ssl_context.load_cert_chain(cert_temp_file.name, key_temp_file.name)
+                signed_ssl_context.verify_mode = ssl.CERT_REQUIRED
 
-            if (IS_WINDOWS):
-                key_temp_file.close()
-                cert_temp_file.close()
+                return signed_ssl_context
+            finally:
                 os.remove(key_temp_file.name)
                 os.remove(cert_temp_file.name)
-
-            return signed_ssl_context

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -29,6 +29,7 @@ PAIR_CERT = "cert"
 PAIR_CA = "ca"
 PAIR_VERSION = "version"
 
+
 class JsonSocket:
     """A socket that reads and writes json objects."""
 
@@ -202,7 +203,9 @@ def _generate_csr_with_ssl_context():
 
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
                 ssl_context.load_verify_locations(cadata=LAP_CA_PEM)
-                ssl_context.load_cert_chain(lap_cert_temp_file.name, lap_key_temp_file.name)
+                ssl_context.load_cert_chain(
+                    lap_cert_temp_file.name, lap_key_temp_file.name
+                )
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
 
                 return csr, key_bytes_pem, ssl_context
@@ -225,7 +228,9 @@ def _generate_signed_ssl_context(key_bytes_pem, cert_pem, ca_pem):
 
                 signed_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
                 signed_ssl_context.load_verify_locations(cadata=ca_pem)
-                signed_ssl_context.load_cert_chain(cert_temp_file.name, key_temp_file.name)
+                signed_ssl_context.load_cert_chain(
+                    cert_temp_file.name, key_temp_file.name
+                )
                 signed_ssl_context.verify_mode = ssl.CERT_REQUIRED
 
                 return signed_ssl_context

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -202,12 +202,12 @@ def _generate_csr_with_ssl_context():
 
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
                 ssl_context.load_verify_locations(cadata=LAP_CA_PEM)
+                lap_key_temp_file.close()
                 ssl_context.load_cert_chain(lap_cert_temp_file.name, lap_key_temp_file.name)
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
 
                 return csr, key_bytes_pem, ssl_context
             finally:
-                lap_key_temp_file.close()
                 lap_cert_temp_file.close()
                 os.remove(lap_key_temp_file.name)
                 os.remove(lap_cert_temp_file.name)

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -6,7 +6,6 @@ import logging
 import socket
 import ssl
 import tempfile
-import os
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend

--- a/pylutron_caseta/pairing.py
+++ b/pylutron_caseta/pairing.py
@@ -28,7 +28,7 @@ PAIR_KEY = "key"
 PAIR_CERT = "cert"
 PAIR_CA = "ca"
 PAIR_VERSION = "version"
-IS_WINDOWS = os.name != "nt"
+IS_WINDOWS = os.name == "nt"
 
 class JsonSocket:
     """A socket that reads and writes json objects."""


### PR DESCRIPTION
Changes
---
* Updated `pairing.py` to check if the current OS is Windows to manually delete the temporary files

Reason for Changes
---
Fixes the `PermissionError: [Errno 13] Permission denied` error that is being thrown when `async_pair` is called on Windows.

Related Issues
---
https://github.com/gurumitts/pylutron-caseta/issues/93