### PR TITLE
Add support for InLineDimmer and InLineSwitch fixes #103

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -5,11 +5,15 @@ from typing import Optional
 from .messages import Response, ResponseStatus
 
 _LEAP_DEVICE_TYPES = {
-    "light": ["WallDimmer", "PlugInDimmer"],
+    "light": ["WallDimmer",
+        "PlugInDimmer",
+        "InLineDimmer",
+    ],
     "switch": [
         "WallSwitch",
         "OutdoorPlugInSwitch",
         "PlugInSwitch",
+        "InLineSwitch",
     ],
     "fan": [
         "CasetaFanSpeedController",


### PR DESCRIPTION
This adds support for additional RA2 Select devices InLineDimmer (model RRK-R25NE-240) and InLineSwitch (model RRK-R6ANS-240)

Tested with RA2 Select main repeater (model RRK-SEL-REP2-BL) in HomeAssistant 2022.7.5

The existing PR for RA3 support includes these changes, but that is more effort to review, and rebasing that PR on these changes will be trivial.