### PR TITLE
Fix bug where only the first character of the bridge/processor's IP address is used by lap-pair

### DIFF
--- a/pylutron_caseta/cli.py
+++ b/pylutron_caseta/cli.py
@@ -129,7 +129,7 @@ async def lap_pair(address: str, cacert: TextIO, cert: TextIO, key: TextIO):
             "pairing."
         )
 
-    data = await async_pair(address[0], _ready)
+    data = await async_pair(address, _ready)
     cacert.write(data["ca"])
     cert.write(data["cert"])
     key.write(data["key"])


### PR DESCRIPTION
The unpatched `leap-pair` CLI has a bug where the call to `async_pair()` was referencing the first character of `address`, which is a string. In the case of an address like 192.168.1.100, the pairing attempt would be made with "1" and returned the error:

```
OSError: [Errno 65] No route to host
```

This PR corrects this by removing the `[0]`. 

Tested by pairing with a Lutron QSX processor:

```
$ lap-pair x.x.x.x
Press the small black button on the back of the bridge to complete pairing.
Successfully paired with 3.223
```

Also tested with a Lutron Caseta bridge to ensure that functionality still worked:

```
$ lap-pair x.x.x.y
Press the small black button on the back of the bridge to complete pairing.
Successfully paired with 1.115
```

pytest shows all tests passing:

<img width="947" alt="image" src="https://user-images.githubusercontent.com/203455/184509236-14dc3e50-460a-49d3-88c1-6c1da0adcc02.png">
