### PR TITLE
RA3/QSX - Add support for RPSCeilingMountedOccupancySensor

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -81,6 +81,7 @@ OCCUPANCY_GROUP_UNKNOWN = "Unknown"
 
 RA3_OCCUPANCY_SENSOR_DEVICE_TYPES = [
     "RPSOccupancySensor",
+    "RPSCeilingMountedOccupancySensor",
 ]
 
 BUTTON_STATUS_PRESSED = "Press"


### PR DESCRIPTION
This PR adds support for a new occupancy sensor device type that has been discovered.

A user that has been helping with testing has a sensor with DeviceType "RPSCeilingMountedOccupancySensor"

Adding this sensor type to RA3_OCCUPANCY_SENSOR_DEVICE_TYPES enables this occupancy sensor.