### PR TITLE
Refactor control station/keypad handling for RA3/QSX

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -43,7 +43,7 @@ _LEAP_DEVICE_TYPES = {
         "Shade",
         "SerenaTiltOnlyWoodBlind",
     ],
-    "sensor": [ # Legacy button device support
+    "sensor": [  # Legacy button device support
         "Pico1Button",
         "Pico2Button",
         "Pico2ButtonRaiseLower",
@@ -55,7 +55,7 @@ _LEAP_DEVICE_TYPES = {
         "Pico4Button2Group",
         "FourGroupRemote",
     ],
-    "keypad": [ # New control station support
+    "keypad": [  # New control station support
         "SeeTouchTabletopKeypad",
         "SunnataKeypad",
         "SeeTouchHybridKeypad",

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -67,6 +67,30 @@ _LEAP_DEVICE_TYPES = {
         "AlisseKeypad",
         "PalladiomKeypad",
     ],
+    "keypad": [
+        "SunnataKeypad",
+        "SeeTouchHybridKeypad",
+        "SeeTouchInternational",
+        "SeeTouchKeypad",
+        "HomeownerKeypad",
+        "GrafikTHybridKeypad",
+        "AlisseKeypad",
+        "PalladiomKeypad",
+    ],
+}
+
+KEYPAD_LED_STATE_UNKNOWN = -1
+KEYPAD_LED_STATE_ON = 100
+KEYPAD_LED_STATE_OFF = 0
+
+BUTTON_TYPE_RAISE = "Raise"
+BUTTON_TYPE_LOWER = "Lower"
+
+_KEYPAD_SPECIAL_BUTTON_MAP = {
+    "HQWT-U-PRW": {
+        16: BUTTON_TYPE_RAISE,
+        17: BUTTON_TYPE_LOWER,
+    },
 }
 
 FAN_OFF = "Off"

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -43,7 +43,7 @@ _LEAP_DEVICE_TYPES = {
         "Shade",
         "SerenaTiltOnlyWoodBlind",
     ],
-    "sensor": [
+    "sensor": [ # Legacy button device support
         "Pico1Button",
         "Pico2Button",
         "Pico2ButtonRaiseLower",
@@ -54,20 +54,9 @@ _LEAP_DEVICE_TYPES = {
         "Pico4ButtonZone",
         "Pico4Button2Group",
         "FourGroupRemote",
-        "SeeTouchTabletopKeypad",
-        "SunnataKeypad",
-        "SunnataKeypad_2Button",
-        "SunnataKeypad_3ButtonRaiseLower",
-        "SunnataKeypad_4Button",
-        "SeeTouchHybridKeypad",
-        "SeeTouchInternational",
-        "SeeTouchKeypad",
-        "HomeownerKeypad",
-        "GrafikTHybridKeypad",
-        "AlisseKeypad",
-        "PalladiomKeypad",
     ],
-    "keypad": [
+    "keypad": [ # New control station support
+        "SeeTouchTabletopKeypad",
         "SunnataKeypad",
         "SeeTouchHybridKeypad",
         "SeeTouchInternational",
@@ -83,13 +72,20 @@ KEYPAD_LED_STATE_UNKNOWN = -1
 KEYPAD_LED_STATE_ON = 100
 KEYPAD_LED_STATE_OFF = 0
 
+# Special button types that can't be labeled by the user
 BUTTON_TYPE_RAISE = "Raise"
 BUTTON_TYPE_LOWER = "Lower"
 
+# Identifies special buttons on keypads that aren't user-programmable
+# such as raise and lower buttons
 _KEYPAD_SPECIAL_BUTTON_MAP = {
     "HQWT-U-PRW": {
         16: BUTTON_TYPE_RAISE,
         17: BUTTON_TYPE_LOWER,
+    },
+    "RRST-W3RL-XX": {
+        18: BUTTON_TYPE_LOWER,
+        19: BUTTON_TYPE_RAISE,
     },
 }
 

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -59,7 +59,9 @@ class Smartbridge:
         self._occupancy_subscribers: Dict[str, Callable[[], None]] = {}
         self._button_subscribers: Dict[str, Callable[[str], None]] = {}
         self._led_device_map: Dict[str, dict] = {}
-        self._ra3_button_map: Dict[str, dict] = {} # Maps buttons back to parent devices
+        self._ra3_button_map: Dict[
+            str, dict
+        ] = {}  # Maps buttons back to parent devices
         self._login_task: Optional[asyncio.Task] = None
         # Use future so we can wait before the login starts and
         # don't need to wait for "login" on reconnect.

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -22,6 +22,10 @@ from . import (
     BUTTON_STATUS_RELEASED,
     BridgeDisconnectedError,
     BridgeResponseError,
+    _KEYPAD_SPECIAL_BUTTON_MAP,
+    KEYPAD_LED_STATE_UNKNOWN,
+    KEYPAD_LED_STATE_ON,
+    KEYPAD_LED_STATE_OFF,
 )
 from .leap import open_connection, id_from_href, LeapProtocol
 from .messages import Response
@@ -54,6 +58,7 @@ class Smartbridge:
         self._subscribers: Dict[str, Callable[[], None]] = {}
         self._occupancy_subscribers: Dict[str, Callable[[], None]] = {}
         self._button_subscribers: Dict[str, Callable[[str], None]] = {}
+        self._led_device_map: Dict[str, dict] = {}
         self._login_task: Optional[asyncio.Task] = None
         # Use future so we can wait before the login starts and
         # don't need to wait for "login" on reconnect.
@@ -295,17 +300,6 @@ class Smartbridge:
         """
         device = self.devices[device_id]
 
-        # Handle keypad LEDs which don't have a zone ID associated
-        if device.get("type") == "KeypadLED":
-            target_state = "On" if value > 0 else "Off"
-            await self._request(
-                "UpdateRequest",
-                f"/led/{device_id}/status",
-                {"LEDStatus": {"State": target_state}},
-            )
-            return
-
-        # All other device types must have an associated zone ID
         zone_id = device.get("zone")
         if not zone_id:
             return
@@ -445,6 +439,61 @@ class Smartbridge:
         """
         await self.set_value(device_id, 0, **kwargs)
 
+    async def set_led_value(
+        self, keypad_device_id: str, button_group_id: str, button_id: str, value: int
+    ):
+        """
+        Will set the value for a device with the given ID.
+
+        :param device_id: device id to set the value on
+        :param value: integer value from 0 to 100 to set
+        :param fade_time: duration for the light to fade from its current value to the
+        new value (only valid for lights)
+        """
+
+        keypad_device = self.devices.get(keypad_device_id)
+        if keypad_device is not None:
+            button_group = keypad_device["button_groups"].get(button_group_id)
+            if button_group is not None:
+                if button_group["buttons"].get(button_id) is not None:
+                    button = button_group["buttons"].get(button_id)
+                    led = button.get("led")
+                    if led is not None:
+                        led_id = led.get("led_id")
+                        target_state = "On" if value > 0 else "Off"
+                        await self._request(
+                            "UpdateRequest",
+                            f"/led/{led_id}/status",
+                            {"LEDStatus": {"State": target_state}},
+                        )
+                        return
+
+        _LOG.error(
+            f"received a set_led_value request for button ID {button_id} which doesn't exist or doesn't have an LED associated"
+        )
+
+    async def turn_led_on(
+        self, keypad_device_id: str, button_group_id: str, button_id: str
+    ):
+        """
+        Will turn 'on' the device with the given ID.
+
+        :param device_id: device id to turn on
+        :param **kwargs: additional parameters for set_value
+        """
+        await self.set_led_value(keypad_device_id, button_group_id, button_id, 100)
+
+    async def turn_led_off(
+        self, keypad_device_id: str, button_group_id: str, button_id: str
+    ):
+        """
+        Will turn 'off' the device with the given ID.
+
+        :param device_id: device id to turn off
+        :param **kwargs: additional parameters for set_value
+        """
+        await self.set_led_value(keypad_device_id, button_group_id, button_id, 0)
+
     async def activate_scene(self, scene_id: str):
         """
         Will activate the scene with the given ID.
@@ -458,18 +507,29 @@ class Smartbridge:
                 {"Command": {"CommandType": "PressAndRelease"}},
             )
 
-    async def tap_button(self, button_id: str):
+    async def tap_button(
+        self, keypad_device_id: str, button_group_id: str, button_id: str
+    ):
         """
         Send a press and release message for the given button ID.
 
+        :param keypad_device_id: device ID of the keypad to which this button belongs
+        :param button_group_id: button group ID to which this button belongs
         :param button_id: button ID, e.g. 23
         """
-        if button_id in self.buttons:
-            await self._request(
-                "CreateRequest",
-                f"/button/{button_id}/commandprocessor",
-                {"Command": {"CommandType": "PressAndRelease"}},
-            )
+        keypad_device = self.devices.get(keypad_device_id)
+        if keypad_device is not None:
+            button_group = keypad_device["button_groups"].get(button_group_id)
+            if button_group is not None:
+                if button_group["buttons"].get(button_id) is not None:
+                    await self._request(
+                        "CreateRequest",
+                        f"/button/{button_id}/commandprocessor",
+                        {"Command": {"CommandType": "PressAndRelease"}},
+                    )
+                    return
+
+        _LOG.error(f"received a tap_button request for unknown button ID {button_id}")
 
     def _get_zone_id(self, device_id: str) -> Optional[str]:
         """
@@ -587,13 +647,49 @@ class Smartbridge:
 
         status = response.Body["LEDStatus"]
         button_led_id = id_from_href(status["LED"]["href"])
-        state = 100 if status["State"] == "On" else 0
+        state = KEYPAD_LED_STATE_ON if status["State"] == "On" else KEYPAD_LED_STATE_OFF
 
-        if button_led_id in self.devices:
-            self.devices[button_led_id]["current_state"] = state
-            # Notify any subscribers of the change to LED status
-            if button_led_id in self._subscribers:
-                self._subscribers[button_led_id]()
+        if button_led_id not in self._led_device_map:
+            _LOG.error(f"received LED status update for unknown LED id {button_led_id}")
+            return
+
+
+        
+
+        device_id = self._led_device_map[button_led_id].get("keypad_device_id")
+        button_group_id = self._led_device_map[button_led_id].get("button_group_id")
+        button_id = self._led_device_map[button_led_id].get("button_id")
+        
+        if device_id is None or button_group_id is None or button_id is None:
+            _LOG.error(
+                f"_led_device_map consistency error: button_led_id = {button_led_id}, "
+                f"device_id = {device_id}, button_group_id = {button_group_id}, "
+                f"button_id = {button_id}"
+            )
+            return
+        
+        device = self.devices.get(device_id)
+        
+        if device is None:
+            _LOG.error(f"*** UNABLE TO FIND DEVICE ID {device_id}")
+            return
+
+        if device["button_groups"].get(button_group_id) is None:
+            _LOG.error(f"*** UNABLE TO FIND BUTTON GROUP ID {button_group_id}")
+            return
+        
+        if device["button_groups"][button_group_id]["buttons"].get(button_id) is None:
+            _LOG.error(f"*** UNABLE TO FIND BUTTON ID {button_id}")
+            return
+
+        # Update state
+        self.devices[device_id]["button_groups"][button_group_id]["buttons"][button_id][
+            "led"
+        ]["current_state"] = state
+
+        # Notify any subscribers of the change to LED status
+        if button_led_id in self._subscribers:
+            self._subscribers[button_led_id]()
 
     def _handle_multi_zone_status(self, response: Response):
         _LOG.debug("Handling multi zone status: %s", response)
@@ -824,6 +920,9 @@ class Smartbridge:
             type=zone_type,
             model=processor["ModelNumber"],
             serial=processor["SerialNumber"],
+            device_type=processor["DeviceType"],
+            processor_name=processor["Name"],
+            area_name=processor_area,
         )
 
     async def _load_ra3_control_stations(self, area):
@@ -844,30 +943,32 @@ class Smartbridge:
             station_name = station["Name"]
             ganged_devices_json = station["AssociatedGangedDevices"]
 
-            combined_name = "_".join((area_name, station_name))
-
             for device_json in ganged_devices_json:
-                await self._load_ra3_station_device(combined_name, device_json)
+                await self._load_ra3_station_device(
+                    area_name, station_name, device_json
+                )
 
-    async def _load_ra3_station_device(self, control_station_name, device_json):
+    async def _load_ra3_station_device(self, area_name, station_name, device_json):
         """
         Load button groups and buttons for a control station device.
 
-        :param control_station_name: the name of the control station
+        :param area_name: area in which this control station device exists
+        :param station_name: name of this control station
         :param device_json: data structure describing the station device
         """
         device_id = id_from_href(device_json["Device"]["href"])
         device_type = device_json["Device"]["DeviceType"]
 
-        # ignore non-button devices
-        if device_type not in _LEAP_DEVICE_TYPES.get("sensor"):
+        # ignore non-keypad devices
+        if device_type not in _LEAP_DEVICE_TYPES.get("keypad"):
             return
 
+        # fetch button details for this device
         button_group_json = await self._request(
             "ReadRequest", f"/device/{device_id}/buttongroup/expanded"
         )
 
-        # ignore button devices without buttons
+        # ignore keypad devices without buttons
         if button_group_json.Body is None:
             return
 
@@ -880,10 +981,14 @@ class Smartbridge:
         else:
             device_serial = None
 
-        button_groups = [
-            id_from_href(group["href"])
-            for group in button_group_json.Body["ButtonGroupsExpanded"]
-        ]
+        button_groups = {}
+        for group in button_group_json.Body["ButtonGroupsExpanded"]:
+            button_group_id = id_from_href(group["href"])
+            buttons = await self._get_ra3_buttons_from_group(device_id, device_model, group)
+            button_groups[button_group_id] = {
+                "button_group_id": button_group_id,
+                "buttons": buttons,
+            }
 
         self.devices.setdefault(
             device_id,
@@ -894,85 +999,96 @@ class Smartbridge:
             },
         ).update(
             zone=None,
-            name="_".join((control_station_name, device_name, device_type)),
-            control_station_name=control_station_name,
+            name=device_name,  # ex: "Keypad 1"
+            area_name=area_name,  # ex: "Foyer"
+            control_station_name=station_name,  # ex: "Front Door Entry Wall"
             button_groups=button_groups,
-            type=device_type,
-            model=device_model,
+            type=device_type,  # ex: "PalladiomKeypad"
+            model=device_model,  # ex: "HQWT-U-P4W"
             serial=device_serial,
         )
+        
+        # Subscribe to button LEDs
+        for button_group in button_groups.values():
+            for button in button_group["buttons"].values():
+                if button["led"] is not None:
+                    button_led_id = button["led"]["led_id"]
+                    await self._subscribe_to_button_led_status(button_led_id)
 
-        for button_expanded_json in button_group_json.Body["ButtonGroupsExpanded"]:
-            for button_json in button_expanded_json["Buttons"]:
-                await self._load_ra3_button(button_json, self.devices[device_id])
+    async def _get_ra3_buttons_from_group(
+        self, keypad_device_id: str, device_model: str, button_group: Dict
+    ) -> Dict:
+        """Create a dictionary of button data and associated LEDs.
 
-    async def _load_ra3_button(self, button_json, keypad_device):
+        :param keypad_device_id (str): Device ID of the keypad to which this button belongs
+        :param device_model (str): Model of the keypad to which this button belongs
+        :param button_group (Dict): Buttons in a button group
+
+        Returns:
+            buttons (Dict): Buttons with associated LEDs if applicable
         """
-        Create button device and load associated button LEDs.
+        button_group_id = id_from_href(button_group["href"])
+        buttons: Dict[str, dict] = {}
 
-        :param button_json: data structure describing this button
-        :param device: data structure describing the keypad device
-        """
-        button_id = id_from_href(button_json["href"])
-        button_number = button_json["ButtonNumber"]
-        button_engraving = button_json.get("Engraving", None)
-        parent_id = id_from_href(button_json["Parent"]["href"])
-        button_led = None
-        button_led_obj = button_json.get("AssociatedLED", None)
-        if button_led_obj is not None:
-            button_led = id_from_href(button_led_obj["href"])
-        if button_engraving is not None and button_engraving["Text"]:
-            button_name = button_engraving["Text"].replace("\n", " ")
-        else:
-            button_name = button_json["Name"]
-        self.buttons.setdefault(
-            button_id,
-            {
+        for button_json in button_group["Buttons"]:
+            button_id = id_from_href(button_json["href"])
+            button_number = button_json["ButtonNumber"]
+            button_engraving = button_json.get("Engraving", None)
+            led = None
+            button_led_obj = button_json.get("AssociatedLED", None)
+            if button_led_obj is not None:
+                button_led_id = id_from_href(button_led_obj["href"])
+                led = {
+                    "led_id": button_led_id,
+                    "current_state": KEYPAD_LED_STATE_UNKNOWN,
+                }
+
+                self._led_device_map[button_led_id] = {
+                    "button_led_id": button_led_id,
+                    "keypad_device_id": keypad_device_id,
+                    "button_group_id": button_group_id,
+                    "button_id": button_id,
+                }
+
+            if button_engraving is not None and button_engraving["Text"]:
+                button_name = button_engraving["Text"].replace("\n", " ")
+            else:
+                button_name = self._get_default_button_name(
+                    device_model, button_number, button_json
+                )
+
+            buttons[button_id] = {
                 "device_id": button_id,
-                "current_state": BUTTON_STATUS_RELEASED,
                 "button_number": button_number,
-                "button_group": parent_id,
-            },
-        ).update(
-            name=keypad_device["name"],
-            type=keypad_device["type"],
-            model=keypad_device["model"],
-            serial=keypad_device["serial"],
-            button_name=button_name,
-            button_led=button_led,
-        )
+                "name": button_name,
+                "led": led,
+            }
 
-        # Load the button LED details
-        if button_led is not None:
-            await self._load_ra3_button_led(button_led, button_id, keypad_device)
+        return buttons
 
-    async def _load_ra3_button_led(self, button_led, button_id, keypad_device):
+    @staticmethod
+    def _get_default_button_name(
+        device_model: str, button_number: int, button_json: Dict
+    ):
+        """Construct the default name for a button.
+
+        For buttons without engraving, determine the default name. This function
+        takes into account the device type and handles special button types like
+        raise and lower.
+
+        :param device_model (str): Model of the keypad to which this button belongs
+        :param button_number (str): Button number of this button on the keypad
+        :param button_json (Dict): The JSON data for this button
+
+        Returns:
+            name (str): Name for this button
         """
-        Create an LED device from a given LEAP button ID.
-
-        :param button_led: LED ID of the button LED
-        :param button_id: device ID of the associated button
-        :param keypad_device: keypad device to which the LED belongs
-        """
-        button = self.buttons[button_id]
-        button_name = button["button_name"]
-        keypad_name = keypad_device["name"]
-
-        self.devices.setdefault(
-            button_led,
-            {
-                "device_id": button_led,
-                "current_state": -1,
-                "fan_speed": None,
-            },
-        ).update(
-            name="_".join((keypad_name, f"{button_name} LED")),
-            type="KeypadLED",
-            model="KeypadLED",
-            serial=None,
-            zone=None,
-        )
-        await self._subscribe_to_button_led_status(button_led)
+        keypad_button_map = _KEYPAD_SPECIAL_BUTTON_MAP.get(device_model)
+        if keypad_button_map is not None:
+            special_button_name = keypad_button_map.get(button_number)
+            if special_button_name is not None:
+                return special_button_name
+        return button_json.get("Name")
 
     async def _load_ra3_zones(self, area):
         # For each area, process zones.  They will masquerade as devices

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -969,8 +969,9 @@ class Smartbridge:
         :param station_name: name of this control station
         :param device_json: data structure describing the station device
         """
-        device_data = device_json.Body["Device"]
-        device_id = id_from_href(device_data["href"])
+        device_id = id_from_href(device_json["Device"]["href"])
+        keypad_device_json = await self._request("ReadRequest", f"/device/{device_id}")
+        device_data = keypad_device_json.Body["Device"]
 
         # ignore non-keypad devices
         if device_data["DeviceType"] not in _LEAP_DEVICE_TYPES.get("keypad"):

--- a/tests/responses/hwqsx/area/1578/controlstation.json
+++ b/tests/responses/hwqsx/area/1578/controlstation.json
@@ -24,6 +24,24 @@
             "GangPosition": 0
           }
         ]
+      },
+      {
+        "href": "/controlstation/1980",
+        "Name": "Back Door",
+        "AssociatedArea": {
+          "href": "/area/1578"
+        },
+        "SortOrder": 1,
+        "AssociatedGangedDevices": [
+          {
+            "Device": {
+              "DeviceType": "PalladiomKeypad",
+              "href": "/device/1982",
+              "AddressedState": "Unaddressed"
+            },
+            "GangPosition": 0
+          }
+        ]
       }
     ]
   }

--- a/tests/responses/hwqsx/device/1982/buttongroup.json
+++ b/tests/responses/hwqsx/device/1982/buttongroup.json
@@ -1,0 +1,92 @@
+{
+  "Header": {
+    "StatusCode": "200 OK",
+    "Url": "/device/1982/buttongroup/expanded",
+    "MessageBodyType": "MultipleButtonGroupExpandedDefinition"
+  },
+  "CommuniqueType": "ReadResponse",
+  "Body": {
+    "ButtonGroupsExpanded": [
+      {
+        "href": "/buttongroup/1990",
+        "Parent": {
+          "href": "/device/1982"
+        },
+        "SortOrder": 0,
+        "ProgrammingType": "Freeform",
+        "Buttons": [
+          {
+            "href": "/button/1991",
+            "ButtonNumber": 1,
+            "ProgrammingModel": {
+              "href": "/programmingmodel/1992",
+              "ProgrammingModelType": "AdvancedToggleProgrammingModel"
+            },
+            "Parent": {
+              "href": "/buttongroup/1990"
+            },
+            "Name": "Button 1",
+            "Engraving": {
+              "Text": ""
+            },
+            "AssociatedLED": {
+              "href": "/led/1987"
+            }
+          },
+          {
+            "href": "/button/1995",
+            "ButtonNumber": 2,
+            "ProgrammingModel": {
+              "href": "/programmingmodel/1996",
+              "ProgrammingModelType": "AdvancedToggleProgrammingModel"
+            },
+            "Parent": {
+              "href": "/buttongroup/1990"
+            },
+            "Name": "Button 2",
+            "Engraving": {
+              "Text": ""
+            },
+            "AssociatedLED": {
+              "href": "/led/1988"
+            }
+          },
+          {
+            "href": "/button/1999",
+            "ButtonNumber": 3,
+            "ProgrammingModel": {
+              "href": "/programmingmodel/2000",
+              "ProgrammingModelType": "AdvancedToggleProgrammingModel"
+            },
+            "Parent": {
+              "href": "/buttongroup/1990"
+            },
+            "Name": "Button 3",
+            "Engraving": {
+              "Text": ""
+            },
+            "AssociatedLED": {
+              "href": "/led/1989"
+            }
+          },
+          {
+            "href": "/button/2003",
+            "ButtonNumber": 16,
+            "Parent": {
+              "href": "/buttongroup/1990"
+            },
+            "Name": "Button 16"
+          },
+          {
+            "href": "/button/2005",
+            "ButtonNumber": 17,
+            "Parent": {
+              "href": "/buttongroup/1990"
+            },
+            "Name": "Button 17"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/responses/hwqsx/device/1982/device.json
+++ b/tests/responses/hwqsx/device/1982/device.json
@@ -1,0 +1,35 @@
+{
+  "Header": {
+    "StatusCode": "200 OK",
+    "Url": "/device/1982",
+    "MessageBodyType": "OneDeviceDefinition"
+  },
+  "CommuniqueType": "ReadResponse",
+  "Body": {
+    "Device": {
+      "Name": "Device 1",
+      "DeviceType": "PalladiomKeypad",
+      "AssociatedArea": {
+        "href": "/area/1578"
+      },
+      "AssociatedControlStation": {
+        "href": "/controlstation/1980",
+        "Name": "Back Door"
+      },
+      "href": "/device/1982",
+      "Parent": {
+        "href": "/project"
+      },
+      "ModelNumber": "HQWT-U-PRW",
+      "LinkNodes": [
+        {
+          "href": "/device/1982/linknode/1984"
+        }
+      ],
+      "DeviceClass": {
+        "HexadecimalEncoding": "1210101"
+      },
+      "AddressedState": "Unaddressed"
+    }
+  }
+}

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -309,7 +309,9 @@ class Bridge:
 
         for station in result.Body.get("ControlStations", []):
             for device in station.get("AssociatedGangedDevices", []):
-                if device["Device"]["DeviceType"] not in _LEAP_DEVICE_TYPES.get("keypad"):
+                if device["Device"]["DeviceType"] not in _LEAP_DEVICE_TYPES.get(
+                    "keypad"
+                ):
                     _LOG.debug("Control station is not a known keypad type - skipping")
                     continue
 
@@ -1992,7 +1994,9 @@ async def test_ra3_button_status_change(ra3_bridge: Bridge):
         )
     )
 
-    new_status = ra3_bridge.target.devices["2939"]["button_groups"]["2942"]["buttons"]["2946"]["current_state"]
+    new_status = ra3_bridge.target.devices["2939"]["button_groups"]["2942"]["buttons"][
+        "2946"
+    ]["current_state"]
     assert new_status == BUTTON_STATUS_PRESSED
     await ra3_bridge.target.close()
 
@@ -2007,7 +2011,7 @@ async def test_ra3_button_status_change_notification(ra3_bridge: Bridge):
         assert status == BUTTON_STATUS_PRESSED
         nonlocal button_notified
         button_notified = True
-        
+
     def keypad_notify():
         nonlocal keypad_notified
         keypad_notified = True
@@ -2194,7 +2198,9 @@ async def test_ra3_set_value_with_fade(ra3_bridge: Bridge, event_loop):
 @pytest.mark.asyncio
 async def test_qsx_set_keypad_led_value(qsx_processor: Bridge, event_loop):
     """Test that setting the value of a keypad LED produces the right command."""
-    task = event_loop.create_task(qsx_processor.target.turn_led_on("1626","1635","1636"))
+    task = event_loop.create_task(
+        qsx_processor.target.turn_led_on("1626", "1635", "1636")
+    )
     command, _ = await qsx_processor.leap.requests.get()
     assert command == Request(
         communique_type="UpdateRequest",
@@ -2257,7 +2263,9 @@ async def test_qsx_set_ketra_level_with_fade(qsx_processor: Bridge, event_loop):
 @pytest.mark.asyncio
 async def test_qsx_tap_button(qsx_processor: Bridge, event_loop):
     """Test that tapping a keypad button produces the right command."""
-    task = event_loop.create_task(qsx_processor.target.tap_button("1409", "1421", "1422"))
+    task = event_loop.create_task(
+        qsx_processor.target.tap_button("1409", "1421", "1422")
+    )
     command, _ = await qsx_processor.leap.requests.get()
     assert command == Request(
         communique_type="CreateRequest",


### PR DESCRIPTION
The way keypad button and button LED handling for RA3/HomeWorks QSX extended the Castea data structures in ways that were not straightforward, and had a number of kluges (like stuffing a bunch of data in the name field with underscore delimiters).

This PR refactors the handling of control station devices. It places the control station device (e.g. keypad) into the device tree, and then button groups, buttons, and LEDs are children to that device. This will be unpacked in Home Assistant to create the appropriate devices for keypads, and entities under them for buttons and button LEDs.

These changes do not impact Pico remotes, and only keypad devices. Pico device handling will require some thought as it will be a breaking change, but would logically fall into this new model.