### PR TITLE
Add support for PhantomKeypad

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -65,6 +65,7 @@ _LEAP_DEVICE_TYPES = {
         "GrafikTHybridKeypad",
         "AlisseKeypad",
         "PalladiomKeypad",
+        "PhantomKeypad",
     ],
 }
 


### PR DESCRIPTION
Adding support for the PhantomKeypad DeviceType.

The PhantomKeypad is the RA2 version of the RA3 HomeOwner Keypad. 
Both of these are virtual Keypads.

DeviceType has been confirmed on my own system.



