### PR TITLE
Fix area tree discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Now discovers the complete area list with working parent_area relationship.
+
 ## [0.17.0] - 2022-10-18
 
 ### Added

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -1111,7 +1111,7 @@ class Smartbridge:
         for area in area_json.Body["Areas"]:
             area_id = id_from_href(area["href"])
             parent_id = None
-            if area.get("IsLeaf", False):
+            if "Parent" in area:
                 parent_id = id_from_href(area["Parent"]["href"])
             self.areas.setdefault(
                 area_id,

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -955,9 +955,9 @@ async def test_area_list(bridge: Bridge):
     """Test the list of areas loaded by the bridge."""
     expected_areas = {
         "1": {"id": "1", "name": "root", "parent_id": None},
-        "2": {"id": "2", "name": "Hallway", "parent_id": None},
-        "3": {"id": "3", "name": "Living Room", "parent_id": None},
-        "4": {"id": "4", "name": "Master Bathroom", "parent_id": None},
+        "2": {"id": "2", "name": "Hallway", "parent_id": "1"},
+        "3": {"id": "3", "name": "Living Room", "parent_id": "1"},
+        "4": {"id": "4", "name": "Master Bathroom", "parent_id": "1"},
     }
 
     assert bridge.target.areas == expected_areas


### PR DESCRIPTION
Currently, the area discovery ignores any area that has the field IsLeaf: False

Unfortunately, this leads to a broken area tree for RA3/HWQSX if the area's don't contain any control stations or devices.

In the example below, both "tree 1" and "tree 2" areas are reported as having "None" parent, because the isLeaf field is False as a consequence of not containing any devices/control stations.
"tree 3" correctly reports it's parent as "tree 2"

![image](https://user-images.githubusercontent.com/24459240/196584162-4ecac4e8-7406-4ff8-accb-b41807442fed.png)

This update ignores the IsLeaf field, and discovers all areas defined on the bridge/processor, maintaining the correct parent/child relationship.
