### PR TITLE
Add gang count and position to ra3/hwqsx control stations

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -851,14 +851,14 @@ class Smartbridge:
         for station in station_json:
             station_name = station["Name"]
             ganged_devices_json = station["AssociatedGangedDevices"]
-
+        
             for device_json in ganged_devices_json:
                 await self._load_ra3_station_device(
-                    area_name, station_name, device_json
+                    area_name, station_name, device_json, len(ganged_devices_json)
                 )
 
     async def _load_ra3_station_device(
-        self, control_station_area_name, control_station_name, device_json
+        self, control_station_area_name, control_station_name, device_json, gang_count
     ):
         """
         Load button groups and buttons for a control station device.
@@ -872,6 +872,8 @@ class Smartbridge:
         # ignore non-button devices
         if device_type not in _LEAP_DEVICE_TYPES.get("sensor"):
             return
+
+        gang_position = device_json["GangPosition"]
 
         button_group_json = await self._request(
             "ReadRequest", f"/device/{device_id}/buttongroup/expanded"
@@ -923,6 +925,8 @@ class Smartbridge:
             control_station_name=control_station_name,
             device_name=device_name,
             area=id_from_href(device_json.Body["Device"]["AssociatedArea"]["href"]),
+            gang_position=gang_position,
+            gang_count=gang_count,
         )
 
         for button_expanded_json in button_group_json.Body["ButtonGroupsExpanded"]:


### PR DESCRIPTION
Adding 2 fields into the devices dict for RA3/HWQSX keypads/picos:
gang_position (which position the keypad resides in a multi-gang station)
gang_count (how many ganged devices are in the control station)

These fields will allow for better device/entity naming.

Currently each keypad has "Position 1" in it's name, even if it's the only keypad in that location. Even a single pico on a pedestal gets the "Position 1" added to it's name.

With these fields, we can detect if it's in a single gang, and ignore the position name.

ie "Rec Room Coffee Table Position 1 Pico" becomes "Rec Room Coffee Table Pico"

The gang_position field will allow us to convert the position to an ordinal (1st, 2nd etc) without having to parse the number out of the device_name field.

