### PR TITLE
Remove deprecated ssl.PROTOCOL_TLSv1_2

### DIFF
--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -108,7 +108,7 @@ class Smartbridge:
     @classmethod
     def create_tls(cls, hostname, keyfile, certfile, ca_certs, port=LEAP_PORT):
         """Initialize the Smart Bridge using TLS over IPv4."""
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(ssl.TLSVersion.TLSv1_2)
         ssl_context.load_verify_locations(ca_certs)
         ssl_context.load_cert_chain(certfile, keyfile)
         ssl_context.verify_mode = ssl.CERT_REQUIRED

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -108,7 +108,8 @@ class Smartbridge:
     @classmethod
     def create_tls(cls, hostname, keyfile, certfile, ca_certs, port=LEAP_PORT):
         """Initialize the Smart Bridge using TLS over IPv4."""
-        ssl_context = ssl.SSLContext(ssl.TLSVersion.TLSv1_2)
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
         ssl_context.load_verify_locations(ca_certs)
         ssl_context.load_cert_chain(certfile, keyfile)
         ssl_context.verify_mode = ssl.CERT_REQUIRED


### PR DESCRIPTION
`PROTOCOL_TLSv1_2` has been deprecated since Python 3.6. Use `ssl.PROTOCOL_TLS_CLIENT` instead.

https://docs.python.org/3/library/ssl.html#ssl.SSLContext