### PR TITLE
Add device type for Wall Mounted Motion Sensor in RA3 Firmware v23.4

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -84,6 +84,7 @@ OCCUPANCY_GROUP_UNKNOWN = "Unknown"
 RA3_OCCUPANCY_SENSOR_DEVICE_TYPES = [
     "RPSOccupancySensor",
     "RPSCeilingMountedOccupancySensor",
+    "RPSWallMountedOccupancySensor",
 ]
 
 BUTTON_STATUS_PRESSED = "Press"


### PR DESCRIPTION
The RA3 firmware that ships with the latest v23.4 Designer software changes the device type of wall mounted occupancy sensors in LEAP to "RPSWallMountedOccupancySensor," which was previously not a part of this library. This changes adds that device type. The new firmware also appears to change the device type of Phantom Keypads, however my debug logs only show device type as "Unknown," so someone with more architecture knowledge may need to step in and help with that change.