### PR TITLE
Fix reconnect race

### DIFF
--- a/pylutron_caseta/leap.py
+++ b/pylutron_caseta/leap.py
@@ -166,7 +166,8 @@ class LeapProtocol:
         self._writer.close()
 
         for request in self._in_flight_requests.values():
-            request.set_exception(BridgeDisconnectedError())
+            if not request.done():
+                request.set_exception(BridgeDisconnectedError())
         self._in_flight_requests.clear()
         self._tagged_subscriptions.clear()
 

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -718,7 +718,8 @@ class Smartbridge:
         except asyncio.CancelledError:
             pass
         except Exception as ex:
-            self._login_completed.set_exception(ex)
+            if not self._login_completed.done():
+                self._login_completed.set_exception(ex)
             raise
 
     async def _ping(self):


### PR DESCRIPTION
Reconnects could fail because the monitor loop would fail due to a request already being done

```
2023-09-26 08:10:57.188 CRITICAL (MainThread) [pylutron_caseta.smartbridge] monitor loop has exited
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pylutron_caseta/smartbridge.py", line 484, in _monitor
    await self._monitor_once()
  File "/usr/local/lib/python3.11/site-packages/pylutron_caseta/smartbridge.py", line 536, in _monitor_once
    self._leap.close()
  File "/usr/local/lib/python3.11/site-packages/pylutron_caseta/leap.py", line 169, in close
    request.set_exception(BridgeDisconnectedError())
asyncio.exceptions.InvalidStateError: invalid state
```

fixes https://github.com/home-assistant/core/issues/100958#issuecomment-1736207797