### PR TITLE
Add Lumaris Tape Light and Ketra color support

### DIFF
--- a/pylutron_caseta/color_value.py
+++ b/pylutron_caseta/color_value.py
@@ -82,7 +82,7 @@ class WarmCoolColorValue(ColorMode):
         """
         Warm Cool color value
 
-        :param kelvin: kelvin value between 1400 and 7000
+        :param kelvin: kelvin value of the bulb
         """
         self.kelvin = kelvin
 

--- a/pylutron_caseta/color_value.py
+++ b/pylutron_caseta/color_value.py
@@ -32,22 +32,21 @@ class ColorValue(ABC):
 
         if "ColorTuningStatus" in zone_status:
             color_status = zone_status["ColorTuningStatus"]
-            if "WhiteTuningLevel" in color_status:
+            curve_dimming = color_status.get("CurveDimming")
+            if curve_dimming is not None and "Curve" in curve_dimming:
+                return WarmDimmingColorValue(True)
+            elif "WhiteTuningLevel" in color_status:
                 kelvin = color_status["WhiteTuningLevel"]["Kelvin"]
                 return WarmCoolColorValue(kelvin)
             elif "HSVTuningLevel" in color_status:
                 hue = color_status["HSVTuningLevel"]["Hue"]
                 saturation = color_status["HSVTuningLevel"]["Saturation"]
                 return FullColorValue(HueSaturationColorParameter(hue, saturation))
-            elif "CurveDimming" in color_status:
-                if color_status["CurveDimming"] is None:
-                    return WarmDimmingColorValue(False)
-                else:
-                    return WarmDimmingColorValue(True)
+
         elif "Vibrancy" in zone_status:
             return VibrancyColorValue(zone_status["Vibrancy"])
-        else:
-            return None
+
+        return None
 
 
 class FullColorParameter(ABC):

--- a/pylutron_caseta/color_value.py
+++ b/pylutron_caseta/color_value.py
@@ -32,13 +32,13 @@ class ColorValue(ABC):
 
         if "ColorTuningStatus" in zone_status:
             color_status = zone_status["ColorTuningStatus"]
-            if "HSVTuningLevel" in color_status:
+            if "WhiteTuningLevel" in color_status:
+                kelvin = color_status["WhiteTuningLevel"]["Kelvin"]
+                return WarmCoolColorValue(kelvin)
+            elif "HSVTuningLevel" in color_status:
                 hue = color_status["HSVTuningLevel"]["Hue"]
                 saturation = color_status["HSVTuningLevel"]["Saturation"]
                 return FullColorValue(HueSaturationColorParameter(hue, saturation))
-            elif "WhiteTuningLevel" in color_status:
-                kelvin = color_status["WhiteTuningLevel"]["Kelvin"]
-                return WarmCoolColorValue(kelvin)
             elif "CurveDimming" in color_status:
                 if color_status["CurveDimming"] is None:
                     return WarmDimmingColorValue(False)

--- a/pylutron_caseta/color_value.py
+++ b/pylutron_caseta/color_value.py
@@ -26,8 +26,9 @@ class ColorMode(ABC):
         """
         pass
 
+
     @staticmethod
-    def get_color_mode_from_leap(zone_status: dict) -> Optional["ColorMode"]:
+    def get_color_from_leap(zone_status: dict) -> Optional["ColorMode"]:
         """
         Gets the color value from the leap command.
 
@@ -37,14 +38,11 @@ class ColorMode(ABC):
         if zone_status is None:
             return None
 
-        if "ColorTuningStatus" not in zone_status:
+        color_status = zone_status.get("ColorTuningStatus")
+        if color_status is None:
             return None
 
-        color_status = zone_status["ColorTuningStatus"]
-        curve_dimming = color_status.get("CurveDimming")
-        if curve_dimming is not None and "Curve" in curve_dimming:
-            return WarmDimmingColorValue(True)
-        elif "WhiteTuningLevel" in color_status:
+        if "WhiteTuningLevel" in color_status:
             kelvin = color_status["WhiteTuningLevel"]["Kelvin"]
             return WarmCoolColorValue(kelvin)
         elif "HSVTuningLevel" in color_status:
@@ -133,7 +131,7 @@ class WarmCoolColorValue(ColorMode):
         }
 
 
-class WarmDimmingColorValue(ColorMode):
+class WarmDimmingColorValue:
     """
     Warm Dimming value
 
@@ -143,6 +141,21 @@ class WarmDimmingColorValue(ColorMode):
     def __init__(self, enabled: bool, additional_params: dict = {}):
         self.enabled = enabled
         self.additional_params = additional_params
+
+    @staticmethod
+    def get_warm_dim_from_leap(zone_status: dict) -> Optional["bool"]:
+        if zone_status is None:
+            return None
+
+        color_status = zone_status.get("ColorTuningStatus")
+        if color_status is None:
+            return None
+
+        curve_dimming = color_status.get("CurveDimming")
+        if curve_dimming is None:
+            return None
+
+        return "Curve" in curve_dimming
 
     def get_leap_parameters(self) -> dict:
         if self.enabled:

--- a/pylutron_caseta/color_value.py
+++ b/pylutron_caseta/color_value.py
@@ -1,0 +1,110 @@
+# protocol which defines a method that returns a dictionary of the leap command given a zone string
+from abc import ABC, abstractmethod
+import colorsys
+
+
+# Protocol for color supported lights
+class ColorValue(ABC):
+    """
+    A protocol for setting the color property of a support light.
+   """
+
+    @abstractmethod
+    def get_spectrum_tuning_level_parameters(self) -> dict:
+        """
+        Gets the relevant parameter dictionary for the spectrum tuning level of the child class.
+
+        :return: spectrum tuning level parameter dictionary
+        """
+        pass
+
+
+class FullColorValue(ColorValue):
+    def __init__(self, r: int, g: int, b: int):
+        """
+        Full Color spectrum value
+
+        :param r: red value between 0 and 255
+        :param g: green value between 0 and 255
+        :param b: blue value between 0 and 255
+        """
+        # convert rgb to hsv, then from 0-1 into 0-360 and 0-100
+        h, s, _ = colorsys.rgb_to_hsv(float(r) / 255.0, float(g) / 255.0, float(b) / 255.0)
+        self.hue = int(h * 360)
+        self.saturation = int(s * 100)
+
+    def get_spectrum_tuning_level_parameters(self) -> dict:
+        return {
+            "ColorTuningStatus": {
+                "HSVTuningLevel":
+                    {
+                        "Hue": self.hue,
+                        "Saturation": self.saturation
+                    }
+            }
+        }
+
+
+class WarmCoolColorValue(ColorValue):
+    def __init__(self, kelvin: int):
+        """
+        Warm Cool color value
+
+        :param kelvin: kelvin value between 1400 and 7000
+        """
+        self.kelvin = kelvin
+
+    def get_spectrum_tuning_level_parameters(self) -> dict:
+        return {
+            "ColorTuningStatus": {
+                "WhiteTuningLevel":
+                    {
+                        "Kelvin": self.kelvin
+                    }
+            }
+        }
+
+
+class WarmDimmingColorValue(ColorValue):
+    """
+    Warm Dimming value
+
+    :param enabled: enable warm dimming
+    """
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def get_spectrum_tuning_level_parameters(self) -> dict:
+
+        if self.enabled:
+            curve_dimming = {
+                "Curve":
+                    {
+                        "href": "/curve/1"
+                    }
+            }
+        else:
+            curve_dimming = None
+
+        return {
+            "ColorTuningStatus":
+                {
+                    "CurveDimming": curve_dimming
+                }
+        }
+
+
+class VibrancyColorValue(ColorValue):
+    def __init__(self, vibrancy: int):
+        """
+        set the vibrancy value
+
+        :param vibrancy: vibrancy value between 0 and 100
+        """
+        self.vibrancy = vibrancy
+
+    def get_spectrum_tuning_level_parameters(self) -> dict:
+        return {
+            "Vibrancy": self.vibrancy
+        }

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -317,7 +317,6 @@ class Smartbridge:
                 "Command": command
             },
         )
-        return
 
     async def set_value(
         self, device_id: str, value: Optional[int] = None, fade_time: Optional[timedelta] = None, color_value: Optional[ColorMode] = None
@@ -328,7 +327,7 @@ class Smartbridge:
         :param device_id: device id to set the value on
         :param value: integer value from 0 to 100 to set (Optional if just setting color)
         :param fade_time: duration for the light to fade from its current value to the
-        :param color_value: color value to set the device to (only currently valid for Ketra devices)
+        :param color_value: color value to set the device to (only currently valid for Ketra/Lumaris devices)
         new value (only valid for lights)
         """
         device = self.devices[device_id]
@@ -613,7 +612,8 @@ class Smartbridge:
         level = status.get("Level", -1)
         fan_speed = status.get("FanSpeed", None)
         tilt = status.get("Tilt", None)
-        color = ColorMode.get_color_mode_from_leap(status)
+        color = ColorMode.get_color_from_leap(status)
+        warm_dim = WarmDimmingColorValue.get_warm_dim_from_leap(status)
 
         _LOG.debug("zone=%s level=%s", zone, level)
         device = self.get_device_by_zone_id(zone)
@@ -624,6 +624,9 @@ class Smartbridge:
         # only update color if it's not None, since color is not reported on brightness changes
         if color is not None:
             device["color"] = color
+        if warm_dim is not None:
+            device["warm_dim"] = warm_dim
+
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
 

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -1043,7 +1043,10 @@ class Smartbridge:
             fan_speed = zone.get("FanSpeed", None)
             zone_name = zone["Name"]
             zone_type = zone["ControlType"]
-            zone_white_tuning_range = zone.get("ColorTuningProperties", {}).get("WhiteTuningLevelRange", None)
+            color_tuning_properties = zone.get("ColorTuningProperties")
+            zone_white_tuning_range = None
+            if color_tuning_properties is not None:
+                zone_white_tuning_range = color_tuning_properties["WhiteTuningLevelRange"]
 
             self.devices.setdefault(
                 zone_id,

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -583,7 +583,9 @@ class Smartbridge:
             device["current_state"] = level
         device["fan_speed"] = fan_speed
         device["tilt"] = tilt
-        device["color"] = color
+        # only update color if it's not None, since color is not reported on brightness changes
+        if color is not None:
+            device["color"] = color
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
 

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -1039,6 +1039,8 @@ class Smartbridge:
             fan_speed = zone.get("FanSpeed", None)
             zone_name = zone["Name"]
             zone_type = zone["ControlType"]
+            zone_white_tuning_range = zone.get("ColorTuningProperties", {}).get("WhiteTuningLevelRange", None)
+
             self.devices.setdefault(
                 zone_id,
                 {"device_id": zone_id, "current_state": level, "fan_speed": fan_speed},
@@ -1051,6 +1053,7 @@ class Smartbridge:
                 serial=None,
                 area=area_id,
                 device_name=zone_name,
+                white_tuning_range=zone_white_tuning_range,
             )
 
     async def _load_lip_devices(self):

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -333,7 +333,11 @@ class Smartbridge:
         
         # Handle Lumaris Tape Light
         if device.get("type") == "WhiteTune":
-            params = {"Level": value}  # type: Dict[str, Union[str, int]]
+            params = {}  # type: Dict[str, Union[str, int]]
+            if value is not None:
+                params["Level"] = value
+            if color_value is not None:
+                params.update(color_value.get_spectrum_tuning_level_parameters())
             if fade_time is not None:
                 params["FadeTime"] = _format_duration(fade_time)
             await self._request(

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -554,12 +554,15 @@ class Smartbridge:
         level = status.get("Level", -1)
         fan_speed = status.get("FanSpeed", None)
         tilt = status.get("Tilt", None)
+        color = ColorValue.get_color_value_from_leap(status)
+
         _LOG.debug("zone=%s level=%s", zone, level)
         device = self.get_device_by_zone_id(zone)
         if level >= 0:
             device["current_state"] = level
         device["fan_speed"] = fan_speed
         device["tilt"] = tilt
+        device["color"] = color
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
 

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -7,6 +7,7 @@ import math
 import socket
 import ssl
 from typing import Callable, Dict, List, Optional, Tuple, Union
+from .color_value import ColorValue
 
 try:
     from asyncio import get_running_loop as get_loop
@@ -281,14 +282,15 @@ class Smartbridge:
         return (response, tag)
 
     async def set_value(
-        self, device_id: str, value: int, fade_time: Optional[timedelta] = None
+        self, device_id: str, value: Optional[int] = None, fade_time: Optional[timedelta] = None, color_value: Optional[ColorValue] = None
     ):
         """
         Will set the value for a device with the given ID.
 
         :param device_id: device id to set the value on
-        :param value: integer value from 0 to 100 to set
+        :param value: integer value from 0 to 100 to set (Optional if just setting color)
         :param fade_time: duration for the light to fade from its current value to the
+        :param color_value: color value to set the device to (only currently valid for Ketra devices)
         new value (only valid for lights)
         """
         device = self.devices[device_id]
@@ -310,7 +312,11 @@ class Smartbridge:
 
         # Handle Ketra lamps
         if device.get("type") == "SpectrumTune":
-            params = {"Level": value}  # type: Dict[str, Union[str, int]]
+            params = {}  # type: Dict[str, Union[str, int]]
+            if value is not None:
+                params["Level"] = value
+            if color_value is not None:
+                params.update(color_value.get_spectrum_tuning_level_parameters())
             if fade_time is not None:
                 params["FadeTime"] = _format_duration(fade_time)
             await self._request(

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -1048,7 +1048,7 @@ class Smartbridge:
             color_tuning_properties = zone.get("ColorTuningProperties")
             zone_white_tuning_range = None
             if color_tuning_properties is not None:
-                zone_white_tuning_range = color_tuning_properties["WhiteTuningLevelRange"]
+                zone_white_tuning_range = color_tuning_properties.get("WhiteTuningLevelRange")
 
             self.devices.setdefault(
                 zone_id,

--- a/tests/responses/hwqsx/area/804/associatedzone.json
+++ b/tests/responses/hwqsx/area/804/associatedzone.json
@@ -64,6 +64,25 @@
             "Max": 10000
           }
         }
+      },
+      {
+        "href": "/zone/989",
+        "Name": "Lumaris Tape Strip",
+        "ControlType": "WhiteTune",
+        "Category": {
+          "Type": "",
+          "IsLight": true
+        },
+        "AssociatedArea": {
+          "href": "/area/804"
+        },
+        "SortOrder": 2,
+        "ColorTuningProperties": {
+          "WhiteTuningLevelRange": {
+            "Min": 1400,
+            "Max": 5000
+          }
+        }
       }
     ]
   }

--- a/tests/responses/hwqsx/device-list.json
+++ b/tests/responses/hwqsx/device-list.json
@@ -151,6 +151,32 @@
         "AddressedState": "Unaddressed"
       },
       {
+        "Name": "Lumaris Tape Strip",
+        "DeviceType": "Lumaris",
+        "AssociatedArea": {
+          "href": "/area/804"
+        },
+        "href": "/device/989",
+        "Parent": {
+          "href": "/project"
+        },
+        "ModelNumber": "HWL-TLK-SW",
+        "LocalZones": [
+          {
+            "href": "/zone/989"
+          }
+        ],
+        "LinkNodes": [
+          {
+            "href": "/device/989/linknode/992"
+          }
+        ],
+        "DeviceClass": {
+          "HexadecimalEncoding": "61a0101"
+        },
+        "AddressedState": "Unaddressed"
+      },
+      {
         "Name": "Keypad 1",
         "DeviceType": "PalladiomKeypad",
         "AssociatedArea": {

--- a/tests/responses/ra3/area/83/associatedzone.json
+++ b/tests/responses/ra3/area/83/associatedzone.json
@@ -19,26 +19,7 @@
                     "href": "/area/83"
                 },
                 "SortOrder": 0
-            },
-            {
-                "href": "/zone/1659",
-                "Name": "Ketra Lights",
-                "ControlType": "SpectrumTune",
-                "Category": {
-                  "Type": "",
-                  "IsLight": true
-                },
-                "AssociatedArea": {
-                  "href": "/area/1578"
-                },
-                "SortOrder": 1,
-                "ColorTuningProperties": {
-                  "WhiteTuningLevelRange": {
-                    "Min": 1400,
-                    "Max": 10000
-                  }
-                }
-              }
+            }
         ]
     }
 }

--- a/tests/responses/ra3/area/83/associatedzone.json
+++ b/tests/responses/ra3/area/83/associatedzone.json
@@ -19,7 +19,26 @@
                     "href": "/area/83"
                 },
                 "SortOrder": 0
-            }
+            },
+            {
+                "href": "/zone/1659",
+                "Name": "Ketra Lights",
+                "ControlType": "SpectrumTune",
+                "Category": {
+                  "Type": "",
+                  "IsLight": true
+                },
+                "AssociatedArea": {
+                  "href": "/area/1578"
+                },
+                "SortOrder": 1,
+                "ColorTuningProperties": {
+                  "WhiteTuningLevelRange": {
+                    "Min": 1400,
+                    "Max": 10000
+                  }
+                }
+              }
         ]
     }
 }

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -31,6 +31,7 @@ from pylutron_caseta import (
     BUTTON_STATUS_PRESSED,
     BridgeDisconnectedError,
     smartbridge,
+    color_value,
 )
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -2170,6 +2171,104 @@ async def test_qsx_set_ketra_level(qsx_processor: Bridge, event_loop):
             "Command": {
                 "CommandType": "GoToSpectrumTuningLevel",
                 "SpectrumTuningLevelParameters": {"Level": 50},
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+    await qsx_processor.target.close()
+
+
+@pytest.mark.asyncio
+async def test_qsx_set_ketra_color(qsx_processor: Bridge, event_loop):
+    """
+    Test that setting the color of a Ketra lamp produces the
+    right command.
+    """
+    hue = 150
+    saturation = 30
+    color = color_value.FullColorValue(color_value.HueSaturationColorParameter(hue, saturation))
+    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/985/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToSpectrumTuningLevel",
+                "SpectrumTuningLevelParameters": {
+                    "ColorTuningStatus": {
+                        "HSVTuningLevel": {
+                            "Hue": hue, "Saturation": saturation
+                        }
+                    }
+                },
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+
+    kelvin = 2700
+    color = color_value.WarmCoolColorValue(kelvin)
+    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/985/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToSpectrumTuningLevel",
+                "SpectrumTuningLevelParameters": {
+                    "ColorTuningStatus": {
+                        "WhiteTuningLevel": {
+                            "Kelvin": kelvin
+                        }
+                    }
+                },
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+
+    color = color_value.WarmDimmingColorValue(True)
+    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/985/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToSpectrumTuningLevel",
+                "SpectrumTuningLevelParameters": {
+                    "ColorTuningStatus": {
+                        "CurveDimming": {
+                            "Curve": {
+                                "href": "/curve/1"
+                            }
+                        }
+                    }
+                },
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+
+    vibrancy = 50
+    color = color_value.VibrancyColorValue(vibrancy)
+    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/985/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToSpectrumTuningLevel",
+                "SpectrumTuningLevelParameters": {
+                    "Vibrancy": vibrancy
+                },
             }
         },
     )

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -708,6 +708,7 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
+            "color": None,
         },
         "3": {
             "area": "2",
@@ -723,6 +724,7 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
+            "color": None,
         },
         "4": {
             "area": "3",
@@ -783,6 +785,7 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
+            "color": None,
         },
         "8": {
             "area": "4",
@@ -828,6 +831,7 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
+            "color": None,
         },
     }
 
@@ -1618,6 +1622,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "1361",
+            "color": None,
+            "white_tuning_range": None,
         },
         "1377": {
             "area": "547",
@@ -1632,6 +1638,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "1377",
+            "color": None,
+            "white_tuning_range": None,
         },
         "1393": {
             "area": "547",
@@ -1646,6 +1654,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Switched",
             "zone": "1393",
+            "color": None,
+            "white_tuning_range": None,
         },
         "1488": {
             "area": "547",
@@ -1674,6 +1684,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2010",
+            "color": None,
+            "white_tuning_range": None,
         },
         "2091": {
             "area": "766",
@@ -1688,6 +1700,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2091",
+            "color": None,
+            "white_tuning_range": None,
         },
         "2107": {
             "area": "766",
@@ -1702,6 +1716,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2107",
+            "color": None,
+            "white_tuning_range": None,
         },
         "2139": {
             "area": "766",
@@ -1868,6 +1884,22 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Switched",
             "zone": "536",
+            "color": None,
+            "white_tuning_range": None,
+        },
+        '1659': {
+            'area': '83',
+            'button_groups': None,
+            'current_state': -1,
+            'device_id': '1659',
+            'device_name': 'Ketra Lights',
+            'fan_speed': None,
+            'model': None,
+            'name': 'Equipment Room_Ketra Lights',
+            'serial': None,
+            'type': 'SpectrumTune',
+            'white_tuning_range': {'Max': 10000, 'Min': 1400},
+            'zone': '1659'
         },
     }
 
@@ -1890,8 +1922,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
     assert devices["1488"]["current_state"] == -1
 
     devices = ra3_bridge.target.get_devices_by_domain("light")
-    assert len(devices) == 5
-    assert devices[0]["device_id"] == "1361"
+    assert len(devices) == 6
+    assert devices[0]["device_id"] == "1659"
 
     devices = ra3_bridge.target.get_devices_by_type("Dimmed")
     assert len(devices) == 5

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2208,7 +2208,7 @@ async def test_qsx_set_ketra_color(qsx_processor: Bridge, event_loop):
     """
     hue = 150
     saturation = 30
-    color = color_value.FullColorValue(color_value.HueSaturationColorParameter(hue, saturation))
+    color = color_value.FullColorValue(hue, saturation)
     task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
     command, _ = await qsx_processor.leap.requests.get()
     assert command == Request(

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2162,7 +2162,6 @@ async def test_ra3_set_value_with_fade(ra3_bridge: Bridge, event_loop):
     await ra3_bridge.target.close()
 
 
-
 @pytest.mark.asyncio
 async def test_qsx_set_keypad_led_value(qsx_processor: Bridge, event_loop):
     """Test that setting the value of a keypad LED produces the right command."""
@@ -2179,20 +2178,20 @@ async def test_qsx_set_keypad_led_value(qsx_processor: Bridge, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_qsx_set_ketra_level(qsx_processor: Bridge, event_loop):
+async def test_qsx_set_whitetune_level(qsx_processor: Bridge, event_loop):
     """
-    Test that setting the level of a Ketra lamp without a fade time produces the
+    Test that setting the level of a White Tune zone without a fade time produces the
     right command.
     """
-    task = event_loop.create_task(qsx_processor.target.set_value("985", 50))
+    task = event_loop.create_task(qsx_processor.target.set_value("989", 50))
     command, _ = await qsx_processor.leap.requests.get()
     assert command == Request(
         communique_type="CreateRequest",
-        url="/zone/985/commandprocessor",
+        url="/zone/989/commandprocessor",
         body={
             "Command": {
-                "CommandType": "GoToSpectrumTuningLevel",
-                "SpectrumTuningLevelParameters": {"Level": 50},
+                "CommandType": "GoToWhiteTuningLevel",
+                "WhiteTuningLevelParameters": {"Level": 50},
             }
         },
     )
@@ -2243,6 +2242,29 @@ async def test_qsx_set_whitetune_temperature(qsx_processor: Bridge, event_loop):
                         }
                     }
                 },
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+    await qsx_processor.target.close()
+
+
+@pytest.mark.asyncio
+async def test_qsx_set_ketra_level(qsx_processor: Bridge, event_loop):
+    """
+    Test that setting the level of a Ketra lamp without a fade time produces the
+    right command.
+    """
+    task = event_loop.create_task(qsx_processor.target.set_value("985", 50))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/985/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToSpectrumTuningLevel",
+                "SpectrumTuningLevelParameters": {"Level": 50},
             }
         },
     )

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2162,6 +2162,7 @@ async def test_ra3_set_value_with_fade(ra3_bridge: Bridge, event_loop):
     await ra3_bridge.target.close()
 
 
+
 @pytest.mark.asyncio
 async def test_qsx_set_keypad_led_value(qsx_processor: Bridge, event_loop):
     """Test that setting the value of a keypad LED produces the right command."""
@@ -2192,6 +2193,56 @@ async def test_qsx_set_ketra_level(qsx_processor: Bridge, event_loop):
             "Command": {
                 "CommandType": "GoToSpectrumTuningLevel",
                 "SpectrumTuningLevelParameters": {"Level": 50},
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+    await qsx_processor.target.close()
+
+
+@pytest.mark.asyncio
+async def test_qsx_set_whitetune_temperature(qsx_processor: Bridge, event_loop):
+    """
+    Test that setting the temperature of a lumaris device produces the
+    right command.
+    """
+    kelvin = 2700
+    color = color_value.WarmCoolColorValue(kelvin)
+    task = event_loop.create_task(qsx_processor.target.set_value("989", color_value=color))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/989/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToWhiteTuningLevel",
+                "WhiteTuningLevelParameters": {
+                    "WhiteTuningLevel": {
+                        "Kelvin": kelvin
+                    }
+                },
+            }
+        },
+    )
+    qsx_processor.leap.requests.task_done()
+    task.cancel()
+
+    task = event_loop.create_task(qsx_processor.target.set_warm_dim("989", True))
+    command, _ = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/989/commandprocessor",
+        body={
+            "Command": {
+                "CommandType": "GoToWarmDim",
+                "WarmDimParameters": {
+                    "CurveDimming": {
+                        "Curve": {
+                            "href": "/curve/1"
+                        }
+                    }
+                },
             }
         },
     )

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2253,8 +2253,7 @@ async def test_qsx_set_ketra_color(qsx_processor: Bridge, event_loop):
     qsx_processor.leap.requests.task_done()
     task.cancel()
 
-    color = color_value.WarmDimmingColorValue(True)
-    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
+    task = event_loop.create_task(qsx_processor.target.set_warm_dim("985", True))
     command, _ = await qsx_processor.leap.requests.get()
     assert command == Request(
         communique_type="CreateRequest",
@@ -2270,25 +2269,6 @@ async def test_qsx_set_ketra_color(qsx_processor: Bridge, event_loop):
                             }
                         }
                     }
-                },
-            }
-        },
-    )
-    qsx_processor.leap.requests.task_done()
-    task.cancel()
-
-    vibrancy = 50
-    color = color_value.VibrancyColorValue(vibrancy)
-    task = event_loop.create_task(qsx_processor.target.set_value("985", color_value=color))
-    command, _ = await qsx_processor.leap.requests.get()
-    assert command == Request(
-        communique_type="CreateRequest",
-        url="/zone/985/commandprocessor",
-        body={
-            "Command": {
-                "CommandType": "GoToSpectrumTuningLevel",
-                "SpectrumTuningLevelParameters": {
-                    "Vibrancy": vibrancy
                 },
             }
         },

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -708,7 +708,6 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
-            "color": None,
         },
         "3": {
             "area": "2",
@@ -724,7 +723,6 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
-            "color": None,
         },
         "4": {
             "area": "3",
@@ -785,7 +783,6 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
-            "color": None,
         },
         "8": {
             "area": "4",
@@ -831,7 +828,6 @@ async def test_device_list(bridge: Bridge):
             "button_groups": None,
             "tilt": None,
             "occupancy_sensors": None,
-            "color": None,
         },
     }
 
@@ -1622,7 +1618,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "1361",
-            "color": None,
             "white_tuning_range": None,
         },
         "1377": {
@@ -1638,7 +1633,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "1377",
-            "color": None,
             "white_tuning_range": None,
         },
         "1393": {
@@ -1654,7 +1648,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Switched",
             "zone": "1393",
-            "color": None,
             "white_tuning_range": None,
         },
         "1488": {
@@ -1684,7 +1677,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2010",
-            "color": None,
             "white_tuning_range": None,
         },
         "2091": {
@@ -1700,7 +1692,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2091",
-            "color": None,
             "white_tuning_range": None,
         },
         "2107": {
@@ -1716,7 +1707,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Dimmed",
             "zone": "2107",
-            "color": None,
             "white_tuning_range": None,
         },
         "2139": {
@@ -1884,7 +1874,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "tilt": None,
             "type": "Switched",
             "zone": "536",
-            "color": None,
             "white_tuning_range": None,
         },
         '1659': {

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -1876,20 +1876,6 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
             "zone": "536",
             "white_tuning_range": None,
         },
-        '1659': {
-            'area': '83',
-            'button_groups': None,
-            'current_state': -1,
-            'device_id': '1659',
-            'device_name': 'Ketra Lights',
-            'fan_speed': None,
-            'model': None,
-            'name': 'Equipment Room_Ketra Lights',
-            'serial': None,
-            'type': 'SpectrumTune',
-            'white_tuning_range': {'Max': 10000, 'Min': 1400},
-            'zone': '1659'
-        },
     }
 
     assert devices == expected_devices
@@ -1911,8 +1897,8 @@ async def test_ra3_device_list(ra3_bridge: Bridge):
     assert devices["1488"]["current_state"] == -1
 
     devices = ra3_bridge.target.get_devices_by_domain("light")
-    assert len(devices) == 6
-    assert devices[0]["device_id"] == "1659"
+    assert len(devices) == 5
+    assert devices[0]["device_id"] == "1361"
 
     devices = ra3_bridge.target.get_devices_by_type("Dimmed")
     assert len(devices) == 5


### PR DESCRIPTION
Here's my initial attempt at adding ketra color support. Includes unit tests, and supports zone status for retrieving the color of the lamp. Let me know if you think something should be changed. Tested and works great on my Ketra bulbs, but can use further confirmation. 
See issue #153 

Corresponding Home Assistant feature branch:
https://github.com/eclair4151/home-assistant-core/tree/ketra_lumaris_color_support

Once you checkout the HA branch, youll need to manually install the new version of pylutron-caseta as well.
Open a terminal in your Home Assistant Core, or the terminal tab in vscode docker, and run

pip uninstall pylutron-caseta    
pip install git+https://github.com/eclair4151/pylutron-caseta.git@dev 

Video of this working in Home Assistant
https://photos.app.goo.gl/VAziwYKXhbo8fo4z7