### PR TITLE
Fix crash related to having no buttons in button group

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -1008,7 +1008,7 @@ class Smartbridge:
         )
 
         for button_expanded_json in button_group_json.Body["ButtonGroupsExpanded"]:
-            for button_json in button_expanded_json["Buttons"]:
+            for button_json in button_expanded_json.get("Buttons",[]):
                 await self._load_ra3_button(button_json, self.devices[device_id])
 
     async def _load_ra3_button(self, button_json, keypad_device):


### PR DESCRIPTION
Using `pylutron-caseta` in Home Assistant, this code crashed on initialization. This change seems to handle the condition that was leading to the crash. See also https://github.com/home-assistant/core/issues/109095