### PR TITLE
invoke bash ./.devcontainer/updateContent.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,5 +17,5 @@
 			]
 		}
 	},
-	"updateContentCommand": "./.devcontainer/updateContent.sh"
+	"updateContentCommand": "bash ./.devcontainer/updateContent.sh"
 }


### PR DESCRIPTION
without "bash" at the start of this command, the devcontainer machinery invokes "sh -c ./.devcontainer/updateContent.sh". 

But this file is not executable, so we get a permissions denied error. Changing the command to

```
bash ./.devcontainer/updateContent.sh
```

tells the build machinery to invoke `bash` (which is executable) and use it to read and execute the specified script. Since `updateContent.sh` is readable, and since `bash` is executable, the build machinery is able to run the `updateContentCommand` script this way.

see https://github.com/gurumitts/pylutron-caseta/issues/158