### PR TITLE
add LEAP Paging/ContinuationToken support

### DIFF
--- a/src/pylutron_caseta/cli.py
+++ b/src/pylutron_caseta/cli.py
@@ -321,7 +321,7 @@ async def leap(
 
     if verbose:
         # LeapProtocol discards the original JSON so reconstruct it here.
-        header = {
+        message = {
             "Header": {
                 "StatusCode": str(response.Header.StatusCode),
                 "Url": response.Header.Url,
@@ -331,9 +331,9 @@ async def leap(
             "Body": response.Body,
         }
         if response.Header.Paging:
-            header["Header"]["Paging"] = response.Header.Paging
+            message["Header"]["Paging"] = response.Header.Paging
 
-        output.write(json.dumps(header))
+        output.write(json.dumps(message))
     else:
         output.write(json.dumps(response.Body))
 

--- a/src/pylutron_caseta/leap.py
+++ b/src/pylutron_caseta/leap.py
@@ -39,6 +39,7 @@ class LeapProtocol:
         url: str,
         body: Optional[dict] = None,
         tag: Optional[str] = None,
+        paging: Optional[dict] = None,
     ) -> Response:
         """Make a request to the bridge and return the response."""
         if tag is None:
@@ -50,6 +51,9 @@ class LeapProtocol:
             "CommuniqueType": communique_type,
             "Header": {"ClientTag": tag, "Url": url},
         }
+
+        if paging is not None:
+            cmd["Header"]["Paging"] = paging
 
         if body is not None:
             cmd["Body"] = body

--- a/src/pylutron_caseta/messages.py
+++ b/src/pylutron_caseta/messages.py
@@ -55,6 +55,7 @@ class ResponseHeader(NamedTuple):
     StatusCode: Optional[ResponseStatus] = None
     Url: Optional[str] = None
     MessageBodyType: Optional[str] = None
+    Paging: Optional[dict] = None
 
     @classmethod
     def from_json(cls, data: dict) -> "ResponseHeader":
@@ -66,6 +67,7 @@ class ResponseHeader(NamedTuple):
             StatusCode=StatusCode,
             Url=data.get("Url", None),
             MessageBodyType=data.get("MessageBodyType", None),
+            Paging=data.get("Paging", None),
         )
 
 

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -251,14 +251,32 @@ class Smartbridge:
         if self._leap is None:
             raise BridgeDisconnectedError()
 
-        async with asyncio_timeout(REQUEST_TIMEOUT):
-            response = await self._leap.request(communique_type, url, body)
+        # LEAP APIs support pagination, so repeat requests until fully collected
+        responses = []
+        paging = None
 
-        status = response.Header.StatusCode
-        if status is None or not status.is_successful():
-            raise BridgeResponseError(response)
+        while True:
+            async with asyncio_timeout(REQUEST_TIMEOUT):
+                response = await self._leap.request(communique_type, url, body, paging=paging)
 
-        return response
+            status = response.Header.StatusCode
+            if status is None or not status.is_successful():
+                raise BridgeResponseError(response)
+
+            responses.append(response)
+
+            paging = response.Header.Paging
+            if not paging:
+                break
+
+        # merge the Body of multiple paged Responses together
+        merged = responses.pop(0)
+        if merged.Body:
+            merged_type = list(merged.Body.keys())[0]
+            for response in responses:
+                merged.Body[merged_type].extend(response.Body[merged_type])
+
+        return merged
 
     async def _subscribe(
         self,

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -272,7 +272,7 @@ class Smartbridge:
         # merge the Body of multiple paged Responses together
         merged = responses.pop(0)
         if merged.Body:
-            merged_type = list(merged.Body.keys())[0]
+            merged_type = next(merged.Body.keys())
             for response in responses:
                 merged.Body[merged_type].extend(response.Body[merged_type])
 


### PR DESCRIPTION
LEAP supports a pagination mechanism when it hits limits on the number of objects returned in a particular API call. I observed this when retrieving more than 99 areas on a QSX system here: https://github.com/gurumitts/pylutron-caseta/issues/152

The response header will contain a Paging object which has a ContinuationToken that should be reflected back into a subsequent request to continue returning additional results.

This PR adds paging support to both the leap client, for manual paging invocation, and the smartbridge interface, by repeating requests until all pagination is complete and the results are merged together.