### PR TITLE
add a helper function test bridge connectivity

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -95,7 +95,7 @@ class Smartbridge:
         except Exception as e:
             _LOG.warning("Test connection to bridge failed: %s", e)
         return False
- 
+
     async def connect(self):
         """Connect to the bridge."""
         # reset any existing connection state

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -83,6 +83,19 @@ class Smartbridge:
             and self._login_completed.exception() is None
         )
 
+    async def test_connection(self) -> bool:
+        """Attempt to connect to the bridge."""
+        try:
+            async with asyncio_timeout(CONNECT_TIMEOUT):
+                leap = await self._connect()
+                leap.close()
+            return True
+        except asyncio.TimeoutError:
+            _LOG.warning("Test connection to bridge timed out")
+        except Exception as e:
+            _LOG.warning("Test connection to bridge failed: %s", e)
+        return False
+ 
     async def connect(self):
         """Connect to the bridge."""
         # reset any existing connection state


### PR DESCRIPTION
Hi there! I'm trying to resolve https://github.com/home-assistant/core/issues/110067

@bdraco suggested having separate timeouts in HA-land for the connection phase vs the full-loading phase of all the leap requests/zones/etc. I'm finding that approach challenging as the _connect() logic is so intertwined in the Smartbridge state machine. Instead, a more simple approach may be to define a helper function that tests connectivity to the bridge, which HA can call to verify connectivity and report any issues back to the user, before the full load which will be given a longer timeout (BRIDGE_TIMEOUT) for large QSX deployments.