### PR TITLE
Fix cancellation being swallowed in tasks

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -611,13 +611,6 @@ class Smartbridge:
         try:
             while True:
                 await self._monitor_once()
-        except asyncio.CancelledError:
-            if (
-                sys.version_info >= (3, 11)
-                and (task := asyncio.current_task())
-                and task.cancelling()
-            ):
-                raise
         except Exception as ex:
             _LOG.critical("monitor loop has exited", exc_info=1)
             if not self._login_completed.done():
@@ -862,13 +855,6 @@ class Smartbridge:
 
             if not self._login_completed.done():
                 self._login_completed.set_result(None)
-        except asyncio.CancelledError:
-            if (
-                sys.version_info >= (3, 11)
-                and (task := asyncio.current_task())
-                and task.cancelling()
-            ):
-                raise
         except Exception as ex:
             if not self._login_completed.done():
                 self._login_completed.set_exception(ex)
@@ -883,13 +869,6 @@ class Smartbridge:
         except asyncio.TimeoutError:
             _LOG.warning("ping was not answered. closing connection.")
             self._leap.close()
-        except asyncio.CancelledError:
-            if (
-                sys.version_info >= (3, 11)
-                and (task := asyncio.current_task())
-                and task.cancelling()
-            ):
-                raise
         except Exception:
             _LOG.warning("ping failed. closing connection.", exc_info=1)
             self._leap.close()

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -5,7 +5,6 @@ import logging
 import math
 import socket
 import ssl
-import sys
 from datetime import timedelta
 from typing import Callable, Dict, List, Optional, Tuple, Union, Coroutine, Any
 from .color_value import ColorMode, WarmDimmingColorValue

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -5,6 +5,7 @@ import logging
 import math
 import socket
 import ssl
+import sys
 from datetime import timedelta
 from typing import Callable, Dict, List, Optional, Tuple, Union, Coroutine, Any
 
@@ -608,7 +609,12 @@ class Smartbridge:
             while True:
                 await self._monitor_once()
         except asyncio.CancelledError:
-            pass
+            if (
+                sys.version_info >= (3, 11)
+                and (task := asyncio.current_task())
+                and task.cancelling()
+            ):
+                raise
         except Exception as ex:
             _LOG.critical("monitor loop has exited", exc_info=1)
             if not self._login_completed.done():
@@ -851,7 +857,12 @@ class Smartbridge:
             if not self._login_completed.done():
                 self._login_completed.set_result(None)
         except asyncio.CancelledError:
-            pass
+            if (
+                sys.version_info >= (3, 11)
+                and (task := asyncio.current_task())
+                and task.cancelling()
+            ):
+                raise
         except Exception as ex:
             if not self._login_completed.done():
                 self._login_completed.set_exception(ex)
@@ -867,7 +878,12 @@ class Smartbridge:
             _LOG.warning("ping was not answered. closing connection.")
             self._leap.close()
         except asyncio.CancelledError:
-            pass
+            if (
+                sys.version_info >= (3, 11)
+                and (task := asyncio.current_task())
+                and task.cancelling()
+            ):
+                raise
         except Exception:
             _LOG.warning("ping failed. closing connection.", exc_info=1)
             self._leap.close()


### PR DESCRIPTION
`asyncio.CancelledError` was being consumed in the task which means `task.cancelled()` can never be true

https://superfastpython.com/asyncio-task-cancellation-best-practices/#Consume_a_CancelledError_Inside_The_Task

Also nothing in this lib ever cares if the task is actually cancelled or not so its fine to close this PR as its only a problem if in the future something would check or care.

