### PR TITLE
Add support for getting a callback on connect success

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -7,7 +7,6 @@ import socket
 import ssl
 from datetime import timedelta
 from typing import Callable, Dict, List, Optional, Tuple, Union, Coroutine, Any
-from contextlib import suppress
 from .color_value import ColorMode, WarmDimmingColorValue
 
 
@@ -1446,8 +1445,6 @@ class Smartbridge:
         for task in (self._monitor_task, self._ping_task, self._login_task):
             if task is not None and not task.done():
                 task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await task
 
 
 def _format_duration(duration: timedelta) -> str:

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -7,7 +7,7 @@ import socket
 import ssl
 from datetime import timedelta
 from typing import Callable, Dict, List, Optional, Tuple, Union, Coroutine, Any
-
+from contextlib import suppress
 from .color_value import ColorMode, WarmDimmingColorValue
 
 
@@ -47,7 +47,9 @@ class Smartbridge:
     """
 
     def __init__(
-        self, connect: Callable[[], Coroutine[Any, Any, LeapProtocol]]
+        self,
+        connect: Callable[[], Coroutine[Any, Any, LeapProtocol]],
+        on_connect_callback: Optional[Callable[[], None]] = None,
     ) -> None:
         """Initialize the Smart Bridge."""
         self.devices: Dict[str, dict] = {}
@@ -69,6 +71,7 @@ class Smartbridge:
         self._leap: Optional[LeapProtocol] = None
         self._monitor_task: Optional[asyncio.Task] = None
         self._ping_task: Optional[asyncio.Task] = None
+        self._on_connect_callback = on_connect_callback
 
     @property
     def logged_in(self):
@@ -83,7 +86,7 @@ class Smartbridge:
             and self._login_completed.exception() is None
         )
 
-    async def connect(self):
+    async def connect(self) -> None:
         """Connect to the bridge."""
         # reset any existing connection state
         if self._login_task is not None:
@@ -135,6 +138,7 @@ class Smartbridge:
         certfile: str,
         ca_certs: str,
         port: int = LEAP_PORT,
+        on_connect_callback: Optional[Callable[[], None]] = None,
     ) -> "Smartbridge":
         """Initialize the Smart Bridge using TLS over IPv4."""
 
@@ -151,7 +155,7 @@ class Smartbridge:
             )
             return res
 
-        return cls(_connect)
+        return cls(_connect, on_connect_callback)
 
     def add_subscriber(self, device_id: str, callback_: Callable[[], None]):
         """
@@ -624,6 +628,9 @@ class Smartbridge:
             self._leap = await self._connect()
             self._leap.subscribe_unsolicited(self._handle_unsolicited)
             _LOG.debug("Successfully connected to Smart Bridge.")
+
+            if self._on_connect_callback:
+                self._on_connect_callback()
 
             if self._login_task is not None:
                 self._login_task.cancel()
@@ -1436,10 +1443,11 @@ class Smartbridge:
     async def close(self):
         """Disconnect from the bridge."""
         _LOG.info("Processing Smartbridge.close() call")
-        if self._monitor_task is not None and not self._monitor_task.cancelled():
-            self._monitor_task.cancel()
-        if self._ping_task is not None and not self._ping_task.cancelled():
-            self._ping_task.cancel()
+        for task in (self._monitor_task, self._ping_task, self._login_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
 
 
 def _format_duration(duration: timedelta) -> str:

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -154,7 +154,7 @@ T = TypeVar("T")
 class Bridge:
     """A test harness around SmartBridge."""
 
-    def __init__(self, on_connect_callback = None):
+    def __init__(self, on_connect_callback=None):
         """Create a new Bridge in a disconnected state."""
         self.connections = asyncio.Queue()
         self.leap = None

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import orjson
 import logging
 import os
-from contextlib import suppress
 import re
 from typing import (
     Any,
@@ -226,8 +225,6 @@ class Bridge:
             self.connections.task_done()
             for task in (connect_task, *running_tasks):
                 task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await task
 
     async def _accept_connection(self, leap, wait):
         """Accept a connection from SmartBridge (implementation)."""

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -154,9 +154,7 @@ T = TypeVar("T")
 class Bridge:
     """A test harness around SmartBridge."""
 
-    def __init__(
-        self, on_connect_callback: Optional[Callable[[], None]] = None
-    ) -> None:
+    def __init__(self, on_connect_callback = None):
         """Create a new Bridge in a disconnected state."""
         self.connections = asyncio.Queue()
         self.leap = None


### PR DESCRIPTION
In HA we want to be able to timeout if connect fails but wait a long time for the initial setup of the subscriptions/data.

Fixes for a few cancellation races

HA PR https://github.com/home-assistant/core/pull/138875