### PR TITLE
Update __init__.py to support SerenaEssentialsRollerShade

### DIFF
--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -50,6 +50,7 @@ _LEAP_DEVICE_TYPES = {
         "Tilt",
         "SerenaTiltOnlyWoodBlind",
         "PalladiomWireFreeShade",
+        "SerenaEssentialsRollerShade"
     ],
     "sensor": [
         "Pico1Button",

--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -50,7 +50,7 @@ _LEAP_DEVICE_TYPES = {
         "Tilt",
         "SerenaTiltOnlyWoodBlind",
         "PalladiomWireFreeShade",
-        "SerenaEssentialsRollerShade"
+        "SerenaEssentialsRollerShade",
     ],
     "sensor": [
         "Pico1Button",


### PR DESCRIPTION
Adding support for new model SerenaEssentialsRollerShade (SYERX-B-X)

ex:

"32": {
    "device_id": "32",
    "current_state": 100,
    "fan_speed": null,
    "tilt": null,
    "zone": "24",
    "name": "Master Bedroom_Master Balcony Shade",
    "button_groups": null,
    "occupancy_sensors": null,
    "type": "SerenaEssentialsRollerShade",
    "model": "SYERX-B-X",
    "serial": 141955679,
    "device_name": "Master Balcony Shade",
    "area": "6"
  }