### PR TITLE
Adds a new button status to detect double press

### DIFF
--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -95,6 +95,7 @@ RA3_OCCUPANCY_SENSOR_DEVICE_TYPES = [
 
 BUTTON_STATUS_PRESSED = "Press"
 BUTTON_STATUS_RELEASED = "Release"
+BUTTON_STATUS_MULTITAP = "MultiTap"
 
 
 class BridgeDisconnectedError(Exception):


### PR DESCRIPTION
Some Keypads, like Alisse, send a MultiTap event every time the user double presses a button. The added const makes it explicit, so integrators like Home Assistant can use it.