### PR TITLE
Introduces a workaround for a bug in Lutron processors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Continuous Integration
 
 on:
-  workflow_dispatch:
   push:
     branches: [dev]
   pull_request:


### PR DESCRIPTION
##  Summary

Under some circumstances, Lutron processors exhibit a bug where zone state changes aren't reported correctly. You can see some videos below of a HomeWorks QSX Processor HQP7-2 showing this behaviour. This pull request introduces a workaround that ensures clients of `pylutron-caseta` remain synchronized even when the processor fails to notify subscribers.

## Problem Description

`pylutron-caseta` relies on subscription updates to notify clients when a light changes state. These state changes can originate from various sources, such as:
- Wall keypads
- The Lutron app
- External automation platforms like Home Assistant

When the Lutron processor fails to send subscription updates, the library becomes blind to externally triggered state changes. This results in incorrect state display in client UIs. 

## Solution

This pull request implements logic to process `CreateResponse` messages after `CreateRequest` commands, ensuring clients are informed of changes initiated by the library itself.
- The library still listens for the usual subscription updates.
- To avoid duplicate or incorrect callbacks, it checks whether a reported light state actually differs from the current one.
- If the state is already correct, no redundant client update is triggered.

### Video from the Lutron App

https://github.com/user-attachments/assets/e996a475-6842-435d-a56f-2055844d039f

Expected result: When toggling a light in the Lutron app, the user interface correctly updates to reflect the new light state.
Actual result: For some lights, the user interface doesn't update.

At the begining of this video capture from the Lutron app, you can see the expected result when turning the "Ceiling 3" light on and off again:
1. The light "Ceiling 3" is off, so the corresponding button in the app is grayed out.
2. When I tap on the button for the "Ceiling 3" light, a new window opens.
3. I turn on the light, and close the window.
4. The user interface shows the light as on, with the "Ceiling 3" button in blue.
5. I repeat steps above to turn the light off, and the button for "Ceiling 3" is again grayed out.

Immediately after, you can spot the bug I'm reporting, when turning the light "Cove" on and off:
1. The light "Cove" is off, so the corresponding button in the app is grayed out.
7. When I tap on the button for the "Cove" light, a new window opens.
8. I turn on the light, and close the window.
9. **BUG: The light still shows as off in the user interface.**
10. When I tap on the button again, it updates to the correct state, showing briefly in blue, and a new window opens.
11. I turn the light off and close the window.
12. **BUG: The light still shows as on in the user interface.**
13. When I tap on the button, a new window opens.
14. I turn off the light, and close the window.
15. **BUG: The light still shows as on in the user interface.**
16. When I tap on the button again, it updates to the correct state, showing briefly in gray, and a new window opens.
17. I close the window without changing the state, to see the button in gray.

### Video from the LEAP session 

https://github.com/user-attachments/assets/bbea553d-580f-47b6-83b8-adef20c074ba

This is not a problem with the client app, but something much deeper, as we can see in this video of a LEAP session with the processor. 

First, the expected behaviour:
1. I subscribe to `/zone/status` with `SubscribeRequest`
2. In the response, I can see I can expect to receive updates about zones `2644` and `1865`, among others.
3. I send a request with `CreateRequest` to turn on zone `2644`.
4. I receive a `CreateResponse` response to my request confirming the execution of the command.
5. And I receive a `ReadResponse` with a state update for zone `2644`, triggered by my suscription.

Now, the bug I found:
1. I send a request with `CreateRequest` to turn on zone `1865`.
7. I correctly receive a `CreateResponse` response to my request confirming the execution of the command.
8. **BUG: I don't receive a `ReadResponse` triggered by my subscription to let me know the area `1865` has changed state.**
9. I send a request with `CreateRequest` to turn off zone `1865`.
10. I correctly receive a `CreateResponse` response to my request confirming the execution of the command.
11. **BUG: I don't receive a `ReadResponse` triggered by my subscription to let me know the area `1865` has changed state.**

