### PR TITLE
Update Smart Away Subscription

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -857,7 +857,7 @@ class Smartbridge:
         self.smart_away_state = status["EnabledState"]
         # Notify any subscribers of the change to Smart Away status
         if self._smart_away_subscriber is not None:
-            self._smart_away_subscriber(self.smart_away_state)
+            self._smart_away_subscriber()
 
     async def _login(self):
         """Connect and login to the Smart Bridge LEAP server using SSL."""


### PR DESCRIPTION
@mdonoughe sorry for the bonus PR, but I am now able to toggle Smart Away in Home Assistant. Hoping to get your opinion on this/some other changes. 

I had issues here unless I removed the state from this commit.
https://github.com/home-assistant/core/blob/dev/homeassistant/components/lutron_caseta/entity.py#L66-L72

I'm wondering if it's worth changing the state to closer align with devices, using `0` as Smart Away off and `1` as on? I had to put a few conditionals in the component code as this isn't aligned with any other device. Is it worth trying to make this look like a device in the pylutron codebase?