### PR TITLE
Add shade battery status support

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -269,9 +269,16 @@ class Smartbridge:
         return self.scenes[scene_id]
 
     async def get_battery_status(self, device_id: str) -> Optional[str]:
-        """Read and cache the battery status for a device, if available."""
+        """Read the battery status for a device, if available."""
         response = await self._request("ReadRequest", f"/device/{device_id}/status")
-        return self._handle_device_status(device_id, response)
+        if response.Body is None:
+            return None
+
+        return (
+            response.Body.get("DeviceStatus", {})
+            .get("BatteryStatus", {})
+            .get("LevelState")
+        )
 
     def is_connected(self) -> bool:
         """Will return True if currently connected to the Smart Bridge."""
@@ -864,40 +871,6 @@ class Smartbridge:
         if self._smart_away_subscriber is not None:
             self._smart_away_subscriber(self.smart_away_state)
 
-    def _handle_device_status(
-        self, device_id: str, response: Response
-    ) -> Optional[str]:
-        """Cache battery state from a device status response."""
-        _LOG.debug("Handling device status for %s: %s", device_id, response)
-        if response.Body is None:
-            return None
-
-        level_state = (
-            response.Body.get("DeviceStatus", {})
-            .get("BatteryStatus", {})
-            .get("LevelState")
-        )
-        if device_id not in self.devices or level_state is None:
-            return None
-
-        self.devices[device_id]["battery_status"] = level_state
-        callback = self._subscribers.get(device_id)
-        if callback is not None:
-            callback()
-        return level_state
-
-    async def _load_battery_statuses(self) -> None:
-        """Populate battery state for cover devices that expose it."""
-        for device in self.get_devices_by_domain("cover"):
-            try:
-                await self.get_battery_status(device["device_id"])
-            except BridgeResponseError as ex:
-                _LOG.debug(
-                    "Skipping battery status for device %s: %s",
-                    device["device_id"],
-                    ex.response,
-                )
-
     async def _login(self):
         """Connect and login to the Smart Bridge LEAP server using SSL."""
         try:
@@ -941,8 +914,6 @@ class Smartbridge:
                             "ReadRequest", f"/zone/{device['zone']}/status"
                         )
                         self._handle_one_zone_status(response)
-
-                await self._load_battery_statuses()
 
             if not self._login_completed.done():
                 self._login_completed.set_result(None)
@@ -1022,8 +993,6 @@ class Smartbridge:
                 device_name=device["Name"],
                 area=area_id,
             )
-            if device["DeviceType"] in _LEAP_DEVICE_TYPES["cover"]:
-                self.devices[device_id].setdefault("battery_status", None)
 
     async def _load_ra3_devices(self):
         for area in self.areas.values():

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -268,6 +268,11 @@ class Smartbridge:
         """
         return self.scenes[scene_id]
 
+    async def get_battery_status(self, device_id: str) -> Optional[str]:
+        """Read and cache the battery status for a device, if available."""
+        response = await self._request("ReadRequest", f"/device/{device_id}/status")
+        return self._handle_device_status(device_id, response)
+
     def is_connected(self) -> bool:
         """Will return True if currently connected to the Smart Bridge."""
         return self.logged_in
@@ -859,6 +864,40 @@ class Smartbridge:
         if self._smart_away_subscriber is not None:
             self._smart_away_subscriber(self.smart_away_state)
 
+    def _handle_device_status(
+        self, device_id: str, response: Response
+    ) -> Optional[str]:
+        """Cache battery state from a device status response."""
+        _LOG.debug("Handling device status for %s: %s", device_id, response)
+        if response.Body is None:
+            return None
+
+        level_state = (
+            response.Body.get("DeviceStatus", {})
+            .get("BatteryStatus", {})
+            .get("LevelState")
+        )
+        if device_id not in self.devices or level_state is None:
+            return None
+
+        self.devices[device_id]["battery_status"] = level_state
+        callback = self._subscribers.get(device_id)
+        if callback is not None:
+            callback()
+        return level_state
+
+    async def _load_battery_statuses(self) -> None:
+        """Populate battery state for cover devices that expose it."""
+        for device in self.get_devices_by_domain("cover"):
+            try:
+                await self.get_battery_status(device["device_id"])
+            except BridgeResponseError as ex:
+                _LOG.debug(
+                    "Skipping battery status for device %s: %s",
+                    device["device_id"],
+                    ex.response,
+                )
+
     async def _login(self):
         """Connect and login to the Smart Bridge LEAP server using SSL."""
         try:
@@ -902,6 +941,8 @@ class Smartbridge:
                             "ReadRequest", f"/zone/{device['zone']}/status"
                         )
                         self._handle_one_zone_status(response)
+
+                await self._load_battery_statuses()
 
             if not self._login_completed.done():
                 self._login_completed.set_result(None)
@@ -981,6 +1022,8 @@ class Smartbridge:
                 device_name=device["Name"],
                 area=area_id,
             )
+            if device["DeviceType"] in _LEAP_DEVICE_TYPES["cover"]:
+                self.devices[device_id].setdefault("battery_status", None)
 
     async def _load_ra3_devices(self):
         for area in self.areas.values():

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -229,6 +229,25 @@ class Bridge:
             for task in (connect_task, *running_tasks):
                 task.cancel()
 
+    @staticmethod
+    def _battery_status_response(url: str, level_state: str = "Good") -> Response:
+        """Build a device status response with battery information."""
+        return Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneDeviceStatus",
+                StatusCode=ResponseStatus(200, "OK"),
+                Url=url,
+            ),
+            Body={
+                "DeviceStatus": {
+                    "href": url,
+                    "Device": {"href": url.removesuffix("/status")},
+                    "BatteryStatus": {"LevelState": level_state},
+                }
+            },
+        )
+
     async def _accept_connection(self, leap, wait):
         """Accept a connection from SmartBridge (implementation)."""
         # Read request on /areas
@@ -334,6 +353,15 @@ class Bridge:
             "/zone/4/status",
             "/zone/6/status",
         ]
+
+        for device in self.target.get_devices_by_domain("cover"):
+            request, response = await wait(leap.requests.get())
+            assert request == Request(
+                communique_type="ReadRequest",
+                url=f"/device/{device['device_id']}/status",
+            )
+            response.set_result(self._battery_status_response(request.url))
+            leap.requests.task_done()
 
     async def _process_station(self, result, leap, wait, bridge_type):
         if result.Body is None:
@@ -804,6 +832,7 @@ async def test_device_list(bridge: Bridge):
         },
         "7": {
             "area": "3",
+            "battery_status": "Good",
             "device_id": "7",
             "device_name": "Living Shade 3",
             "name": "Living Room_Living Shade 3",
@@ -849,6 +878,7 @@ async def test_device_list(bridge: Bridge):
         },
         "10": {
             "area": "3",
+            "battery_status": "Good",
             "device_id": "10",
             "device_name": "Blinds",
             "name": "Living Room_Blinds",
@@ -864,6 +894,7 @@ async def test_device_list(bridge: Bridge):
         },
         "11": {
             "area": "3",
+            "battery_status": "Good",
             "device_id": "11",
             "device_name": "WoodBlinds",
             "name": "Living Room_WoodBlinds",

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -354,15 +354,6 @@ class Bridge:
             "/zone/6/status",
         ]
 
-        for device in self.target.get_devices_by_domain("cover"):
-            request, response = await wait(leap.requests.get())
-            assert request == Request(
-                communique_type="ReadRequest",
-                url=f"/device/{device['device_id']}/status",
-            )
-            response.set_result(self._battery_status_response(request.url))
-            leap.requests.task_done()
-
     async def _process_station(self, result, leap, wait, bridge_type):
         if result.Body is None:
             return
@@ -832,7 +823,6 @@ async def test_device_list(bridge: Bridge):
         },
         "7": {
             "area": "3",
-            "battery_status": "Good",
             "device_id": "7",
             "device_name": "Living Shade 3",
             "name": "Living Room_Living Shade 3",
@@ -878,7 +868,6 @@ async def test_device_list(bridge: Bridge):
         },
         "10": {
             "area": "3",
-            "battery_status": "Good",
             "device_id": "10",
             "device_name": "Blinds",
             "name": "Living Room_Blinds",
@@ -894,7 +883,6 @@ async def test_device_list(bridge: Bridge):
         },
         "11": {
             "area": "3",
-            "battery_status": "Good",
             "device_id": "11",
             "device_name": "WoodBlinds",
             "name": "Living Room_WoodBlinds",
@@ -998,6 +986,20 @@ async def test_device_list(bridge: Bridge):
 
     devices = bridge.target.get_devices_by_type("Tilt")
     assert [device["device_id"] for device in devices] == ["11"]
+
+
+@pytest.mark.asyncio
+async def test_get_battery_status(bridge: Bridge):
+    """Test reading battery status on demand."""
+    task = asyncio.create_task(bridge.target.get_battery_status("7"))
+
+    request, response = await asyncio.wait_for(bridge.leap.requests.get(), 10)
+    assert request == Request(communique_type="ReadRequest", url="/device/7/status")
+    response.set_result(bridge._battery_status_response(request.url))
+    bridge.leap.requests.task_done()
+
+    assert await asyncio.wait_for(task, 10) == "Good"
+    assert "battery_status" not in bridge.target.get_device_by_id("7")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Shade position is exposed on `/zone/{zone_id}/status`, but battery information is exposed separately on `/device/{device_id}/status`.

This PR reads `/device/{device_id}/status` for Caseta shade devices and stores `BatteryStatus.LevelState` on the existing device dict as `battery_status`.

Tested by running `tests/test_smartbridge.py` (`50 passed`).