### PR TITLE
Fix Ketra warm-dim color mode stuck after initial state set

### DIFF
--- a/src/pylutron_caseta/color_value.py
+++ b/src/pylutron_caseta/color_value.py
@@ -108,10 +108,8 @@ class WarmDimmingColorValue:
         Check whether warm dimming is active for a zone status.
 
         Returns None if the zone status does not contain warm dimming information.
-        Returns False if ColorTuningStatus is present but CurveDimming is absent,
-        meaning the bridge has sent a non-warm-dim color update (e.g. HSVTuningLevel
-        from a Ketra fixture) and warm-dim mode should be cleared.
-        Returns True if CurveDimming is present and contains a Curve entry.
+        Returns False if warm diming is inactive
+        Returns True if warm diming is active
         """
         if zone_status is None:
             return None
@@ -122,7 +120,6 @@ class WarmDimmingColorValue:
 
         curve_dimming = color_status.get("CurveDimming")
         if curve_dimming is None:
-            # ColorTuningStatus is present but no CurveDimming — warm-dim is off
             return False
 
         return "Curve" in curve_dimming

--- a/src/pylutron_caseta/color_value.py
+++ b/src/pylutron_caseta/color_value.py
@@ -108,6 +108,10 @@ class WarmDimmingColorValue:
         Check whether warm dimming is active for a zone status.
 
         Returns None if the zone status does not contain warm dimming information.
+        Returns False if ColorTuningStatus is present but CurveDimming is absent,
+        meaning the bridge has sent a non-warm-dim color update (e.g. HSVTuningLevel
+        from a Ketra fixture) and warm-dim mode should be cleared.
+        Returns True if CurveDimming is present and contains a Curve entry.
         """
         if zone_status is None:
             return None
@@ -118,7 +122,8 @@ class WarmDimmingColorValue:
 
         curve_dimming = color_status.get("CurveDimming")
         if curve_dimming is None:
-            return None
+            # ColorTuningStatus is present but no CurveDimming — warm-dim is off
+            return False
 
         return "Curve" in curve_dimming
 


### PR DESCRIPTION
## Problem

When a Ketra SpectrumTune fixture is in warm-dim mode, Home Assistant correctly captures the initial state on integration start. However, subsequent color changes (from either the Lutron app or HA) are not reflected in Home Assistant until the integration is restarted.

## Root Cause

When the bridge sends a `ColorTuningStatus` update containing `HSVTuningLevel` (or `XYTuningLevel`) but no `CurveDimming` field, `get_warm_dim_from_leap` returns `None` — meaning "no warm-dim information, leave the flag alone."

This is correct when `ColorTuningStatus` is entirely absent. However, when `ColorTuningStatus` *is* present but simply lacks `CurveDimming`, it means the fixture is actively in a non-warm-dim color mode and the flag should be cleared.

Because `device["warm_dim"]` was never cleared, `color_mode` kept returning `ColorMode.WHITE` indefinitely, masking the correctly-updated `FullColorValue` color state.

## Fix

In `get_warm_dim_from_leap`: when `ColorTuningStatus` is present but `CurveDimming` is absent, return `False` (warm-dim explicitly off) instead of `None` (no opinion). One-line behavioral change.

## Testing

Verified on Ketra SpectrumTune fixtures via RA3/QSX bridge with the Home Assistant lutron_caseta integration. Color state now updates correctly when switching out of warm-dim mode without requiring an integration restart.

Fixes #200 