### PR TITLE
Add support for Vierti Hybrid Keypad (RadioRA 3)

### DIFF
--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -76,6 +76,7 @@ _LEAP_DEVICE_TYPES = {
         "AlisseKeypad",
         "PalladiomKeypad",
         "PhantomKeypad",
+        "N-CVLpqtTTOIeG-4hcjKgw",  # Vierti Hybrid Keypad (HD-4B, HD-3RL)
     ],
 }
 

--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -4,6 +4,33 @@ from typing import Optional
 
 from .messages import Response, ResponseStatus
 
+_PICOS = [
+    "Pico1Button",
+    "Pico2Button",
+    "Pico2ButtonRaiseLower",
+    "Pico3Button",
+    "Pico3ButtonRaiseLower",
+    "Pico4Button",
+    "Pico4ButtonScene",
+    "Pico4ButtonZone",
+    "Pico4Button2Group",
+    "PaddleSwitchPico",
+]
+
+_KEYPADS = [
+    "SeeTouchTabletopKeypad",
+    "SunnataKeypad",
+    "SunnataHybridKeypad",
+    "SeeTouchHybridKeypad",
+    "SeeTouchKeypad",
+    "HomeownerKeypad",
+    "GrafikTHybridKeypad",
+    "AlisseKeypad",
+    "PalladiomKeypad",
+    "PhantomKeypad",
+    "N-CVLpqtTTOIeG-4hcjKgw",  # Vierti Hybrid Keypad (HD-4B, HD-3RL)
+]
+
 _LEAP_DEVICE_TYPES = {
     "light": [
         "WallDimmer",
@@ -54,30 +81,11 @@ _LEAP_DEVICE_TYPES = {
         "SerenaEssentialsRollerShade",
     ],
     "sensor": [
-        "Pico1Button",
-        "Pico2Button",
-        "Pico2ButtonRaiseLower",
-        "Pico3Button",
-        "Pico3ButtonRaiseLower",
-        "Pico4Button",
-        "Pico4ButtonScene",
-        "Pico4ButtonZone",
-        "Pico4Button2Group",
-        "PaddleSwitchPico",
         "FourGroupRemote",
-        "SeeTouchTabletopKeypad",
-        "SunnataKeypad",
-        "SunnataHybridKeypad",
-        "SeeTouchHybridKeypad",
         "SeeTouchInternational",
-        "SeeTouchKeypad",
-        "HomeownerKeypad",
-        "GrafikTHybridKeypad",
-        "AlisseKeypad",
-        "PalladiomKeypad",
-        "PhantomKeypad",
-        "N-CVLpqtTTOIeG-4hcjKgw",  # Vierti Hybrid Keypad (HD-4B, HD-3RL)
-    ],
+    ]
+    + _PICOS
+    + _KEYPADS,
 }
 
 FAN_OFF = "Off"

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -1092,6 +1092,8 @@ class Smartbridge:
             device_type_friendly = "Pico"
         elif "Keypad" in device_type:
             device_type_friendly = "Keypad"
+        elif device_type == "N-CVLpqtTTOIeG-4hcjKgw":
+            device_type_friendly = "ViertiKeypad"
 
         if "SerialNumber" in device_json.Body["Device"]:
             device_serial = device_json.Body["Device"]["SerialNumber"]

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -1093,7 +1093,7 @@ class Smartbridge:
         elif "Keypad" in device_type:
             device_type_friendly = "Keypad"
         elif device_type == "N-CVLpqtTTOIeG-4hcjKgw":
-            device_type_friendly = "ViertiKeypad"
+            device_type_friendly = "Keypad"
 
         if "SerialNumber" in device_json.Body["Device"]:
             device_serial = device_json.Body["Device"]["SerialNumber"]

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -17,7 +17,9 @@ except ImportError:
     from asyncio import get_event_loop as get_loop
 
 from . import (
+    _KEYPADS,
     _LEAP_DEVICE_TYPES,
+    _PICOS,
     BUTTON_STATUS_RELEASED,
     FAN_OFF,
     OCCUPANCY_GROUP_UNKNOWN,
@@ -1088,11 +1090,9 @@ class Smartbridge:
             (control_station_area_name, control_station_name)
         )
 
-        if "Pico" in device_type:
+        if device_type in _PICOS:
             device_type_friendly = "Pico"
-        elif "Keypad" in device_type:
-            device_type_friendly = "Keypad"
-        elif device_type == "N-CVLpqtTTOIeG-4hcjKgw":
+        elif device_type in _KEYPADS:
             device_type_friendly = "Keypad"
 
         if "SerialNumber" in device_json.Body["Device"]:


### PR DESCRIPTION
## Summary

The Vierti Hybrid Keypad is a newer RadioRA 3 device that combines a dimmer with keypad buttons (models HD-4B and HD-3RL). The LEAP API reports these with an obfuscated device type string `N-CVLpqtTTOIeG-4hcjKgw` rather than a human-readable name like other keypads (e.g. `SunnataKeypad`).

Because this device type is not in `_LEAP_DEVICE_TYPES["sensor"]`, the `_load_ra3_station_device` method silently skips these devices, meaning no button entities are created and no button events are fired.

## Changes

- Added `N-CVLpqtTTOIeG-4hcjKgw` to the `sensor` list in `_LEAP_DEVICE_TYPES`
- Added a friendly name mapping (`ViertiKeypad`) in `_load_ra3_station_device` since the obfuscated string doesn't match the existing `"Keypad" in device_type` check

## Environment

- RadioRA 3 processor running LEAP v3.247
- Vierti models: HD-4B (4-button hybrid) and HD-3RL (3-button with raise/lower hybrid)
- The dimmer zones for these devices already work correctly via `_load_ra3_zones`; only the keypad button discovery was missing

## LEAP API data

The device type was identified by querying `/area/{id}/associatedcontrolstation` on the RA3 processor:

```json
{
  "Device": {
    "href": "/device/558",
    "DeviceType": "N-CVLpqtTTOIeG-4hcjKgw",
    "AddressedState": "Addressed"
  }
}
```

Individual device query (`/device/558`) confirmed:

```json
{
  "ModelNumber": "HD-4B",
  "SerialNumber": 128610831,
  "LocalZones": [{"href": "/zone/589"}],
  "LinkNodes": [{"href": "/device/558/linknode/560"}]
}
```