### PR TITLE
Handle missing battery status endpoint

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -270,7 +270,13 @@ class Smartbridge:
 
     async def get_battery_status(self, device_id: str) -> Optional[str]:
         """Read the battery status for a device, if available."""
-        response = await self._request("ReadRequest", f"/device/{device_id}/status")
+        try:
+            response = await self._request("ReadRequest", f"/device/{device_id}/status")
+        except BridgeResponseError as ex:
+            if ex.code is not None and ex.code.code == 404:
+                return None
+            raise
+
         if response.Body is None:
             return None
 

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -1003,6 +1003,29 @@ async def test_get_battery_status(bridge: Bridge):
 
 
 @pytest.mark.asyncio
+async def test_get_battery_status_not_found(bridge: Bridge):
+    """Test missing battery status endpoint returns no battery status."""
+    task = asyncio.create_task(bridge.target.get_battery_status("7"))
+
+    request, response = await asyncio.wait_for(bridge.leap.requests.get(), 10)
+    assert request == Request(communique_type="ReadRequest", url="/device/7/status")
+    response.set_result(
+        Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneDeviceStatus",
+                StatusCode=ResponseStatus(404, "Not Found"),
+                Url=request.url,
+            ),
+            Body=None,
+        )
+    )
+    bridge.leap.requests.task_done()
+
+    assert await asyncio.wait_for(task, 10) is None
+
+
+@pytest.mark.asyncio
 async def test_lip_device_list(bridge: Bridge):
     """Test methods getting devices."""
     devices = bridge.target.lip_devices


### PR DESCRIPTION
## Summary

- Treat a `404` response from `/device/{device_id}/status` as missing battery status rather than raising `BridgeResponseError`
- Keep other bridge errors unchanged/re-raised

## Context

Home Assistant 2026.5 added Lutron shade battery entities that call `get_battery_status()` for covers. Some systems can expose a cover while returning `404` for the device status endpoint, which should mean battery status is unavailable for that device rather than causing repeated update errors.