### PR TITLE
Close connection when re-login fails so login is retried

### DIFF
--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -930,6 +930,21 @@ class Smartbridge:
         except Exception as ex:
             if not self._login_completed.done():
                 self._login_completed.set_exception(ex)
+            else:
+                # The initial login already completed on a previous
+                # connection, so nothing is awaiting this task and the
+                # failure would otherwise be silent. If the connection were
+                # left open, requests would keep working but the
+                # subscriptions that deliver zone, button, and occupancy
+                # status updates were never re-established, leaving the
+                # bridge half-alive. Close the connection so that _monitor
+                # reconnects and login is retried until it completes.
+                _LOG.warning(
+                    "Re-login failed after reconnect. Closing connection.",
+                    exc_info=1,
+                )
+                if self._leap is not None:
+                    self._leap.close()
             raise
 
     async def _ping(self):

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -1644,6 +1644,47 @@ async def test_reconnect_error(bridge: Bridge):
 
 
 @pytest.mark.asyncio
+async def test_relogin_failure_closes_connection(bridge: Bridge):
+    """Test that a failed re-login tears down the connection and retries.
+
+    Regression test for the "half-alive" state seen when a processor reboots:
+    if a request made during re-login fails (for example, it times out because
+    the processor is still starting up), the bridge must close the connection
+    and retry login on a new connection instead of leaving a session where
+    commands work but status subscriptions were never re-established.
+    """
+    time = 0.0
+    asyncio.get_running_loop().time = lambda: time  # type: ignore [method-assign]
+
+    bridge.disconnect()
+
+    await asyncio.sleep(0.0)
+    time += smartbridge.RECONNECT_DELAY
+
+    # Accept the new connection, but fail the first login request, simulating
+    # a processor that accepts connections but is too slow to answer.
+    leap = await bridge.connections.get()
+    request, response = await leap.requests.get()
+    assert request == Request(communique_type="ReadRequest", url="/area")
+    response.set_exception(asyncio.TimeoutError())
+    leap.requests.task_done()
+    bridge.connections.task_done()
+
+    # The bridge should close the half-logged-in connection and reconnect.
+    # accept_connection completes the full login sequence, including
+    # re-subscribing to status updates.
+    # Yield until the monitor loop has observed the closed connection and
+    # scheduled its reconnect delay, then advance the clock past the delay.
+    for _ in range(10):
+        await asyncio.sleep(0.0)
+    time += smartbridge.RECONNECT_DELAY
+
+    await bridge.accept_connection()
+
+    assert bridge.target.is_connected()
+
+
+@pytest.mark.asyncio
 async def test_reconnect_timeout():
     """Test that SmartBridge can reconnect if the remote does not respond."""
     bridge = Bridge()


### PR DESCRIPTION
Fixes #206

After a reconnect, `_login()` runs as a fire-and-forget task. If it raises (e.g. a request times out against a processor that is still booting), the failure is silent: `_login_completed` is already resolved from the initial session, nothing awaits `_login_task`, and the connection stays open. Requests keep working, but the status subscriptions — which live in the new connection's `LeapProtocol._tagged_subscriptions` and are only registered by `_login()` — are never re-established. The bridge is then permanently "half-alive": commands succeed, status updates never arrive.

This change makes a failed re-login close the connection (mirroring `_ping()`'s existing failure handling). `LeapProtocol.run()` then ends, `_monitor` reconnects after `RECONNECT_DELAY`, and login retries until it completes, subscriptions included. Initial-connect behavior is unchanged (`connect()` still surfaces the exception via `_login_completed`).

Adds `test_relogin_failure_closes_connection`, following the existing `test_reconnect_*` fake-time/fake-LEAP conventions in `tests/test_smartbridge.py`. It hangs (fails on timeout) without the fix and passes with it. Full suite: 60 passed.
