### PR TITLE
Add OpenCloseStop cover discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,35 @@ async def example():
 asyncio.run(example())
 ```
 
+### Open/close/stop covers
+
+HomeWorks QSX and RadioRA 3 projects expose logical zones through the LEAP
+`/area/{area_id}/associatedzone` resource. `pylutron-caseta` represents each
+zone as a device and uses its `ControlType` for domain classification. A zone
+whose control type is exactly `OpenCloseStop` is returned by
+`get_devices_by_domain("cover")`, regardless of its zone ID, area name, load
+name, or physical motor controller.
+
+This supports any HomeWorks QSX or RadioRA 3 project that reports the same
+LEAP control type; it is not specific to a particular processor serial number
+or motor module. It does not imply support for older HomeWorks protocols or
+for a different, previously unknown `ControlType`. `OpenCloseStop` also does
+not identify whether the physical load is a shade, blind, curtain, or another
+kind of open/close motor.
+
+These zones accept `raise_cover`, `lower_cover`, and `stop_cover`, which send
+the LEAP `Raise`, `Lower`, and `Stop` commands. When the processor does not
+report a level, `current_state` remains `-1`; Raise and Lower do not
+optimistically change it to 100 or 0.
+
+An `OpenCloseStop` zone notification may contain only the zone identity, with
+no level, direction, command, motion state, or command source. Such a
+notification invokes the existing device subscriber but cannot by itself
+distinguish Raise from Lower. Callers also must not rely on Stop producing a
+zone notification. Applications that estimate position should correlate
+their own commands or separately observed controls and otherwise treat the
+position as unknown.
+
 ### The leap tool
 
 For development and testing of new features, there is a `leap` command in the cli extras (`pip install pylutron_caseta[cli]`) which can be used for communicating directly with the bridge, similar to using `curl`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ zone notification. Applications that estimate position should correlate
 their own commands or separately observed controls and otherwise treat the
 position as unknown.
 
+These limitations describe the QSX `OpenCloseStop` notifications observed so
+far; they are not a guarantee that every device, project, or future Lutron
+release will omit the same attributes. The existing zone-status handler
+already consumes `Level` when one is present. If another implementation later
+reports direction, command, motion, or source attributes, support can be
+extended from captured protocol evidence without changing the general
+`OpenCloseStop` discovery classification.
+
 ### The leap tool
 
 For development and testing of new features, there is a `leap` command in the cli extras (`pip install pylutron_caseta[cli]`) which can be used for communicating directly with the bridge, similar to using `curl`.

--- a/src/pylutron_caseta/__init__.py
+++ b/src/pylutron_caseta/__init__.py
@@ -79,6 +79,7 @@ _LEAP_DEVICE_TYPES = {
         "SerenaTiltOnlyWoodBlind",
         "PalladiomWireFreeShade",
         "SerenaEssentialsRollerShade",
+        "OpenCloseStop",
     ],
     "sensor": [
         "FourGroupRemote",

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -527,18 +527,18 @@ class Smartbridge:
     async def raise_cover(self, device_id: str):
         """Will raise a cover."""
         await self._send_zone_create_request(device_id, "Raise")
-        # If set_value is called, we get an optimistic callback right
-        # away with the value, if we use Raise we have to set it
-        # as one won't come unless Stop is called or something goes wrong.
-        self.devices[device_id]["current_state"] = 100
+        # Position-capable covers need an optimistic endpoint because Raise does not
+        # produce an immediate callback. OpenCloseStop zones have no position state.
+        if self.devices[device_id]["type"] != "OpenCloseStop":
+            self.devices[device_id]["current_state"] = 100
 
     async def lower_cover(self, device_id: str):
         """Will lower a cover."""
         await self._send_zone_create_request(device_id, "Lower")
-        # If set_value is called, we get an optimistic callback right
-        # away with the value, if we use Lower we have to set it
-        # as one won't come unless Stop is called or something goes wrong.
-        self.devices[device_id]["current_state"] = 0
+        # Position-capable covers need an optimistic endpoint because Lower does not
+        # produce an immediate callback. OpenCloseStop zones have no position state.
+        if self.devices[device_id]["type"] != "OpenCloseStop":
+            self.devices[device_id]["current_state"] = 0
 
     async def set_fan(self, device_id: str, value: str):
         """

--- a/tests/responses/hwqsx/area/1020/associatedzone.json
+++ b/tests/responses/hwqsx/area/1020/associatedzone.json
@@ -32,6 +32,19 @@
           "href": "/area/1020"
         },
         "SortOrder": 0
+      },
+      {
+        "href": "/zone/1999",
+        "Name": "Motorized Window Treatment",
+        "ControlType": "OpenCloseStop",
+        "Category": {
+          "Type": "",
+          "IsLight": false
+        },
+        "AssociatedArea": {
+          "href": "/area/1020"
+        },
+        "SortOrder": 1
       }
     ]
   }

--- a/tests/responses/hwqsx/zonestatus.json
+++ b/tests/responses/hwqsx/zonestatus.json
@@ -58,6 +58,11 @@
       "StatusAccuracy": "Good"
     },
     {
+      "Zone": {
+        "href": "/zone/1999"
+      }
+    },
+    {
       "href": "/zone/1362/status",
       "Level": 0,
       "Zone": {

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2290,6 +2290,48 @@ async def test_qsx_set_keypad_led_value(qsx_processor: Bridge):
     await qsx_processor.target.close()
 
 
+@pytest.mark.parametrize(
+    ("method_name", "command_type"),
+    [
+        ("raise_cover", "Raise"),
+        ("lower_cover", "Lower"),
+        ("stop_cover", "Stop"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_qsx_open_close_stop_cover_command(
+    qsx_processor: Bridge, method_name: str, command_type: str
+):
+    """Test commands for an OpenCloseStop cover without inventing state."""
+    devices = qsx_processor.target.get_devices_by_domain("cover")
+    device = next(device for device in devices if device["device_id"] == "1999")
+    assert device["type"] == "OpenCloseStop"
+    assert device["current_state"] == -1
+
+    method = getattr(qsx_processor.target, method_name)
+    task = asyncio.get_running_loop().create_task(method("1999"))
+    command, response = await qsx_processor.leap.requests.get()
+    assert command == Request(
+        communique_type="CreateRequest",
+        url="/zone/1999/commandprocessor",
+        body={"Command": {"CommandType": command_type}},
+    )
+    response.set_result(
+        Response(
+            CommuniqueType="CreateResponse",
+            Header=ResponseHeader(
+                StatusCode=ResponseStatus(201, "Created"),
+                Url="/zone/1999/commandprocessor",
+            ),
+        ),
+    )
+    qsx_processor.leap.requests.task_done()
+    await task
+
+    assert device["current_state"] == -1
+    await qsx_processor.target.close()
+
+
 @pytest.mark.asyncio
 async def test_qsx_set_whitetune_level(qsx_processor: Bridge):
     """


### PR DESCRIPTION
## Summary

- discover HomeWorks QSX zones reporting `ControlType: OpenCloseStop` as covers
- route Raise, Lower, and Stop through the standard LEAP zone command endpoints
- keep state unknown because these zones do not report a position
- document the observed notification limits and future extension point

## Applicability

Discovery is based on the Lutron control type, not on a processor model, project-specific zone ID, or room name. It should therefore apply to installations where QSX enumerates a zone as `OpenCloseStop` and accepts the standard Raise, Lower, and Stop commands.

The sanitized fixture also covers an identity-only zone-status entry. The notifications observed from these zones did not contain level, direction, or motion attributes, so this change deliberately preserves `current_state == -1` after discovery and commands instead of treating the device like a position-capable shade. If another device or future Lutron firmware supplies additional raw status attributes, direction or position support can be added separately without changing this discovery behavior.

## Validation

- test suite passes on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- Python 3.14 Ruff formatting/checks and mypy pass
- wheel and source distribution build successfully as version `0.29.0`
- exact LEAP Raise, Lower, and Stop request URLs and bodies are covered

The fixture and documentation contain no processor address, certificate, room name, serial number, or installation-specific zone ID.
