### PR TITLE
Add on_disconnect_callback parameter to Smartbridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional callback for disconnection events.
 - `BUTTON_STATUS_LONG_HOLD` constant for the `LongHold` LEAP button event
   emitted by HomeWorks QSX processors.
 

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -51,6 +51,7 @@ class Smartbridge:
         self,
         connect: Callable[[], Coroutine[Any, Any, LeapProtocol]],
         on_connect_callback: Optional[Callable[[], None]] = None,
+        on_disconnect_callback: Optional[Callable[[], None]] = None,
     ) -> None:
         """Initialize the Smart Bridge."""
         self.devices: Dict[str, dict] = {}
@@ -75,6 +76,8 @@ class Smartbridge:
         self._monitor_task: Optional[asyncio.Task] = None
         self._ping_task: Optional[asyncio.Task] = None
         self._on_connect_callback = on_connect_callback
+        self._on_disconnect_callback = on_disconnect_callback
+        self._connected = False
 
     @property
     def logged_in(self):
@@ -142,6 +145,7 @@ class Smartbridge:
         ca_certs: str,
         port: int = LEAP_PORT,
         on_connect_callback: Optional[Callable[[], None]] = None,
+        on_disconnect_callback: Optional[Callable[[], None]] = None,
     ) -> "Smartbridge":
         """Initialize the Smart Bridge using TLS over IPv4."""
 
@@ -158,7 +162,7 @@ class Smartbridge:
             )
             return res
 
-        return cls(_connect, on_connect_callback)
+        return cls(_connect, on_connect_callback, on_disconnect_callback)
 
     def add_subscriber(self, device_id: str, callback_: Callable[[], None]):
         """
@@ -687,6 +691,7 @@ class Smartbridge:
 
             if self._on_connect_callback:
                 self._on_connect_callback()
+            self._connected = True
 
             if self._login_task is not None:
                 self._login_task.cancel()
@@ -698,6 +703,9 @@ class Smartbridge:
             self._ping_task = asyncio.get_running_loop().create_task(self._ping())
 
             await self._leap.run()
+            if self._connected and self._on_disconnect_callback:
+                self._on_disconnect_callback()
+            self._connected = False
             _LOG.warning("LEAP session ended. Reconnecting...")
             await asyncio.sleep(RECONNECT_DELAY)
         # ignore OSError too.
@@ -709,6 +717,9 @@ class Smartbridge:
             asyncio.TimeoutError,
             BridgeDisconnectedError,
         ) as ex:
+            if self._connected and self._on_disconnect_callback:
+                self._on_disconnect_callback()
+            self._connected = False
             _LOG.warning("Reconnecting after error: %s", ex)
             await asyncio.sleep(RECONNECT_DELAY)
         finally:

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -77,7 +77,7 @@ class Smartbridge:
         self._ping_task: Optional[asyncio.Task] = None
         self._on_connect_callback = on_connect_callback
         self._on_disconnect_callback = on_disconnect_callback
-        self._connected = False
+        self._notified_connected = False
 
     @property
     def logged_in(self):
@@ -691,7 +691,7 @@ class Smartbridge:
 
             if self._on_connect_callback:
                 self._on_connect_callback()
-            self._connected = True
+            self._notified_connected = True
 
             if self._login_task is not None:
                 self._login_task.cancel()
@@ -703,11 +703,7 @@ class Smartbridge:
             self._ping_task = asyncio.get_running_loop().create_task(self._ping())
 
             await self._leap.run()
-            if self._connected and self._on_disconnect_callback:
-                self._on_disconnect_callback()
-            self._connected = False
             _LOG.warning("LEAP session ended. Reconnecting...")
-            await asyncio.sleep(RECONNECT_DELAY)
         # ignore OSError too.
         # sometimes you get OSError instead of ConnectionError.
         except (
@@ -717,11 +713,7 @@ class Smartbridge:
             asyncio.TimeoutError,
             BridgeDisconnectedError,
         ) as ex:
-            if self._connected and self._on_disconnect_callback:
-                self._on_disconnect_callback()
-            self._connected = False
             _LOG.warning("Reconnecting after error: %s", ex)
-            await asyncio.sleep(RECONNECT_DELAY)
         finally:
             if self._login_task is not None:
                 self._login_task.cancel()
@@ -734,6 +726,16 @@ class Smartbridge:
             if self._leap is not None:
                 self._leap.close()
                 self._leap = None
+
+        if self._notified_connected:
+            self._notified_connected = False
+            if self._on_disconnect_callback:
+                try:
+                    self._on_disconnect_callback()
+                except Exception:
+                    _LOG.exception("Got exception from on_disconnect_callback")
+
+        await asyncio.sleep(RECONNECT_DELAY)
 
     def _handle_one_zone_status(self, response: Response):
         _LOG.debug("Handling single zone status: %s", response)

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -153,10 +153,11 @@ T = TypeVar("T")
 class Bridge:
     """A test harness around SmartBridge."""
 
-    def __init__(self, on_connect_callback=None):
+    def __init__(self, on_connect_callback=None, on_disconnect_callback=None):
         """Create a new Bridge in a disconnected state."""
         self.connections = asyncio.Queue()
         self.leap = None
+        self._on_disconnect_callback = on_disconnect_callback
 
         self.button_list_result = response_from_json_file("buttons.json")
         self.occupancy_group_list_result = response_from_json_file(
@@ -185,7 +186,9 @@ class Bridge:
             await self.connections.put(leap)
             return leap
 
-        self.target = smartbridge.Smartbridge(fake_connect, on_connect_callback)
+        self.target = smartbridge.Smartbridge(
+            fake_connect, on_connect_callback, on_disconnect_callback
+        )
 
     async def initialize(self, processor=CASETA_PROCESSOR):
         """Perform the initial connection with SmartBridge."""
@@ -3030,3 +3033,43 @@ async def test_on_connect_callback() -> None:
         await init_task
 
     await bridge.target.close()
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_callback() -> None:
+    """Test that the on disconnect callback is called when connection is lost."""
+    loop = asyncio.get_running_loop()
+    disconnect_future: asyncio.Future[None] = loop.create_future()
+
+    def _on_disconnect_callback() -> None:
+        if not disconnect_future.done():
+            disconnect_future.set_result(None)
+
+    bridge = Bridge(on_disconnect_callback=_on_disconnect_callback)
+    await bridge.initialize(CASETA_PROCESSOR)
+
+    # Simulate connection loss by closing the leap connection
+    bridge.leap.close()
+
+    # Wait for disconnect callback to be called
+    await asyncio.wait_for(disconnect_future, timeout=5.0)
+
+    await bridge.target.close()
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_callback_not_called_on_intentional_close() -> None:
+    """Test that the on disconnect callback is NOT called on intentional close()."""
+    disconnect_called = False
+
+    def _on_disconnect_callback() -> None:
+        nonlocal disconnect_called
+        disconnect_called = True
+
+    bridge = Bridge(on_disconnect_callback=_on_disconnect_callback)
+    await bridge.initialize(CASETA_PROCESSOR)
+
+    # Intentionally close the bridge - should NOT trigger disconnect callback
+    await bridge.target.close()
+
+    assert not disconnect_called


### PR DESCRIPTION
## Summary

Adds an optional `on_disconnect_callback` parameter to `Smartbridge`, mirroring the existing `on_connect_callback` pattern. The callback fires once when the connection transitions from connected to disconnected.

## Motivation

Home Assistant's Lutron Caséta integration needs to mark entities as unavailable when the bridge goes offline. Currently there's no way to detect unexpected disconnections without polling `is_connected()`.

Related to Home Assistant's [Integration Quality Scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/entity-unavailable/) which requires entities to be marked unavailable when their device/service is unreachable.

## Design decisions

- **Does NOT fire on intentional `close()`**: Only fires for unexpected disconnections (session ended or connection error)