### PR TITLE
Expose raw zone status events

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ reports direction, command, motion, or source attributes, support can be
 extended from captured protocol evidence without changing the general
 `OpenCloseStop` discovery classification.
 
+Raw zone-status subscribers receive a recursively immutable copy of each
+status. A subscriber cannot modify the event observed by another subscriber;
+mapping values are read-only and list values are exposed as tuples.
+
 ### The leap tool
 
 For development and testing of new features, there is a `leap` command in the cli extras (`pip install pylutron_caseta[cli]`) which can be used for communicating directly with the bridge, similar to using `curl`.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,19 @@ reports direction, command, motion, or source attributes, support can be
 extended from captured protocol evidence without changing the general
 `OpenCloseStop` discovery classification.
 
-Raw zone-status subscribers receive a recursively immutable copy of each
-status. A subscriber cannot modify the event observed by another subscriber;
-mapping values are read-only and list values are exposed as tuples.
+### Raw zone-status events
+
+`Smartbridge.add_zone_status_subscriber` provides an opt-in event stream for
+callers that need the original zone status in addition to normalized device
+state. Each event identifies the zone and resolved device, includes the raw
+status payload, and classifies the status as an initial snapshot or an
+operational update. The method supports multiple subscribers and returns an
+idempotent unsubscribe callback; existing device subscribers are unchanged.
+
+Subscribers receive a recursively immutable copy of each status. A subscriber
+cannot modify the event observed by another subscriber; mapping values are
+read-only and list values are exposed as tuples. Subscriber exceptions are
+logged without interrupting normal state processing or other subscribers.
 
 ### The leap tool
 

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -1,12 +1,15 @@
 """Provides an API to interact with the Lutron Caseta Smart Bridge & RA3 Processor."""
 
 import asyncio
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
 import logging
 import math
 import socket
 import ssl
 from datetime import timedelta
-from typing import Callable, Dict, List, Optional, Tuple, Union, Coroutine, Any
+from typing import Any, Callable, Coroutine, Dict, List, Mapping, Optional, Tuple, Union
 from .color_value import ColorMode, WarmDimmingColorValue
 
 
@@ -40,6 +43,23 @@ REQUEST_TIMEOUT = 5.0
 RECONNECT_DELAY = 2.0
 
 
+class ZoneStatusEventOrigin(Enum):
+    """Identify whether a zone status is a snapshot or a live update."""
+
+    INITIAL = "initial"
+    UPDATE = "update"
+
+
+@dataclass(frozen=True)
+class ZoneStatusEvent:
+    """Describe a zone status without interpreting device-specific attributes."""
+
+    zone_id: str
+    device_id: str
+    status: Mapping[str, Any]
+    origin: ZoneStatusEventOrigin
+
+
 class Smartbridge:
     """
     A representation of the Lutron Caseta Smart Bridge.
@@ -62,6 +82,7 @@ class Smartbridge:
         self.smart_away_state: str = ""
         self._connect = connect
         self._subscribers: Dict[str, Callable[[], None]] = {}
+        self._zone_status_subscribers: List[Callable[[ZoneStatusEvent], None]] = []
         self._occupancy_subscribers: Dict[str, Callable[[], None]] = {}
         self._button_subscribers: Dict[str, Callable[[str], None]] = {}
         self._smart_away_subscriber: Optional[Callable[[str], None]] = None
@@ -168,6 +189,21 @@ class Smartbridge:
         :param callback_: callback to invoke
         """
         self._subscribers[device_id] = callback_
+
+    def add_zone_status_subscriber(
+        self, callback_: Callable[[ZoneStatusEvent], None]
+    ) -> Callable[[], None]:
+        """Subscribe to raw zone statuses and return an idempotent unsubscribe call."""
+        if not callable(callback_):
+            raise TypeError("callback must be callable")
+
+        self._zone_status_subscribers.append(callback_)
+
+        def unsubscribe() -> None:
+            if callback_ in self._zone_status_subscribers:
+                self._zone_status_subscribers.remove(callback_)
+
+        return unsubscribe
 
     def add_occupancy_subscriber(
         self, occupancy_group_id: str, callback_: Callable[[], None]
@@ -729,9 +765,11 @@ class Smartbridge:
         body = response.Body
         if body is None:
             return
-        self._handle_zone_status(body["ZoneStatus"])
+        self._handle_zone_status(body["ZoneStatus"], ZoneStatusEventOrigin.UPDATE)
 
-    def _handle_zone_status(self, status):
+    def _handle_zone_status(
+        self, status: dict[str, Any], origin: ZoneStatusEventOrigin
+    ) -> None:
         zone = id_from_href(status["Zone"]["href"])
         level = status.get("Level", -1)
         fan_speed = status.get("FanSpeed", None)
@@ -754,6 +792,18 @@ class Smartbridge:
 
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
+
+        event = ZoneStatusEvent(
+            zone_id=zone,
+            device_id=device["device_id"],
+            status=deepcopy(status),
+            origin=origin,
+        )
+        for callback in tuple(self._zone_status_subscribers):
+            try:
+                callback(event)
+            except Exception:  # pylint: disable=broad-except
+                _LOG.exception("Zone status subscriber raised an exception")
 
     def _handle_button_status(self, response: Response):
         _LOG.debug("Handling button status: %s", response)
@@ -791,14 +841,18 @@ class Smartbridge:
             if button_led_id in self._subscribers:
                 self._subscribers[button_led_id]()
 
-    def _handle_multi_zone_status(self, response: Response):
+    def _handle_multi_zone_status(
+        self,
+        response: Response,
+        origin: ZoneStatusEventOrigin = ZoneStatusEventOrigin.UPDATE,
+    ) -> None:
         _LOG.debug("Handling multi zone status: %s", response)
 
         if response.Body is None:
             return
 
         for zonestatus in response.Body["ZoneStatuses"]:
-            self._handle_zone_status(zonestatus)
+            self._handle_zone_status(zonestatus, origin)
 
     def _handle_occupancy_group_status(self, response: Response):
         _LOG.debug("Handling occupancy group status: %s", response)
@@ -1506,7 +1560,7 @@ class Smartbridge:
         except BridgeResponseError as ex:
             _LOG.error("Failed zone subscription: %s", ex.response)
             return
-        self._handle_multi_zone_status(response)
+        self._handle_multi_zone_status(response, ZoneStatusEventOrigin.INITIAL)
 
     async def _subscribe_to_smart_away_status(self):
         """Subscribe to Smart Away status updates."""

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -9,6 +9,7 @@ import math
 import socket
 import ssl
 from datetime import timedelta
+from types import MappingProxyType
 from typing import Any, Callable, Coroutine, Dict, List, Mapping, Optional, Tuple, Union
 from .color_value import ColorMode, WarmDimmingColorValue
 
@@ -58,6 +59,17 @@ class ZoneStatusEvent:
     device_id: str
     status: Mapping[str, Any]
     origin: ZoneStatusEventOrigin
+
+
+def _immutable_copy(value: Any) -> Any:
+    """Copy a JSON-like value into recursively immutable containers."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _immutable_copy(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_immutable_copy(item) for item in value)
+    return deepcopy(value)
 
 
 class Smartbridge:
@@ -796,7 +808,7 @@ class Smartbridge:
         event = ZoneStatusEvent(
             zone_id=zone,
             device_id=device["device_id"],
-            status=deepcopy(status),
+            status=_immutable_copy(status),
             origin=origin,
         )
         for callback in tuple(self._zone_status_subscribers):

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -210,10 +210,14 @@ class Smartbridge:
             raise TypeError("callback must be callable")
 
         self._zone_status_subscribers.append(callback_)
+        subscribed = True
 
         def unsubscribe() -> None:
-            if callback_ in self._zone_status_subscribers:
-                self._zone_status_subscribers.remove(callback_)
+            nonlocal subscribed
+            if not subscribed:
+                return
+            subscribed = False
+            self._zone_status_subscribers.remove(callback_)
 
         return unsubscribe
 
@@ -772,12 +776,16 @@ class Smartbridge:
                 self._leap.close()
                 self._leap = None
 
-    def _handle_one_zone_status(self, response: Response):
+    def _handle_one_zone_status(
+        self,
+        response: Response,
+        origin: ZoneStatusEventOrigin = ZoneStatusEventOrigin.UPDATE,
+    ) -> None:
         _LOG.debug("Handling single zone status: %s", response)
         body = response.Body
         if body is None:
             return
-        self._handle_zone_status(body["ZoneStatus"], ZoneStatusEventOrigin.UPDATE)
+        self._handle_zone_status(body["ZoneStatus"], origin)
 
     def _handle_zone_status(
         self, status: dict[str, Any], origin: ZoneStatusEventOrigin
@@ -804,6 +812,9 @@ class Smartbridge:
 
         if device["device_id"] in self._subscribers:
             self._subscribers[device["device_id"]]()
+
+        if not self._zone_status_subscribers:
+            return
 
         event = ZoneStatusEvent(
             zone_id=zone,
@@ -987,7 +998,9 @@ class Smartbridge:
                         response = await self._request(
                             "ReadRequest", f"/zone/{device['zone']}/status"
                         )
-                        self._handle_one_zone_status(response)
+                        self._handle_one_zone_status(
+                            response, ZoneStatusEventOrigin.INITIAL
+                        )
 
             if not self._login_completed.done():
                 self._login_completed.set_result(None)

--- a/tests/responses/hwqsx/zonestatus.json
+++ b/tests/responses/hwqsx/zonestatus.json
@@ -1,5 +1,12 @@
 {
-  "ZoneStatuses": [
+  "CommuniqueType": "SubscribeResponse",
+  "Header": {
+    "MessageBodyType": "MultipleZoneStatus",
+    "StatusCode": "200 OK",
+    "Url": "/zone/status"
+  },
+  "Body": {
+    "ZoneStatuses": [
     {
       "href": "/zone/816/status",
       "Level": 0,
@@ -126,5 +133,6 @@
       },
       "StatusAccuracy": "Good"
     }
-  ]
+    ]
+  }
 }

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
+    cast,
 )
 import pytest
 import pytest_asyncio
@@ -2358,6 +2359,7 @@ async def test_qsx_zone_status_events(bridge_uninit: Bridge):
     status: Dict[str, Any] = {
         "Zone": {"href": "/zone/1999"},
         "FutureDirection": "Opening",
+        "FutureSources": [{"href": "/device/123"}],
     }
     bridge_uninit.leap.send_unsolicited(
         Response(
@@ -2377,7 +2379,17 @@ async def test_qsx_zone_status_events(bridge_uninit: Bridge):
     assert update_event.origin is smartbridge.ZoneStatusEventOrigin.UPDATE
     assert update_event.status["FutureDirection"] == "Opening"
     assert update_event.status["Zone"]["href"] == "/zone/1999"
+    assert update_event.status["FutureSources"][0]["href"] == "/device/123"
     assert bridge_uninit.target.get_device_by_id("1999")["current_state"] == -1
+
+    with pytest.raises(TypeError):
+        cast(Any, update_event.status)["FutureDirection"] = "Closing"
+    with pytest.raises(TypeError):
+        update_event.status["Zone"]["href"] = "/zone/mutated"
+    with pytest.raises(AttributeError):
+        update_event.status["FutureSources"].append({"href": "/device/456"})
+
+    assert second_events[-1].status == update_event.status
 
     unsubscribe()
     unsubscribe()

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -647,7 +647,7 @@ class Bridge:
         else:
             self.leap.running.set_exception(exception)
 
-    async def accept_connection(self):
+    async def accept_connection(self, processor=CASETA_PROCESSOR):
         """Wait for SmartBridge to reconnect."""
         leap = await self.connections.get()
 
@@ -656,7 +656,14 @@ class Bridge:
             result = await coro
             return result
 
-        await self._accept_connection(leap, wait)
+        if processor == CASETA_PROCESSOR:
+            await self._accept_connection(leap, wait)
+        elif processor == RA3_PROCESSOR:
+            await self._accept_connection_ra3(leap, wait)
+        elif processor == HWQSX_PROCESSOR:
+            self.qsx_button_list.clear()
+            self.qsx_button_led_list.clear()
+            await self._accept_connection_qsx(leap, wait)
 
         self.leap = leap
         self.connections.task_done()
@@ -2330,6 +2337,80 @@ async def test_qsx_open_close_stop_cover_command(
 
     assert device["current_state"] == -1
     await qsx_processor.target.close()
+
+
+@pytest.mark.asyncio
+async def test_qsx_zone_status_events(bridge_uninit: Bridge):
+    """Test raw zone status subscribers receive snapshots and live updates."""
+    first_events: List[smartbridge.ZoneStatusEvent] = []
+    second_events: List[smartbridge.ZoneStatusEvent] = []
+    unsubscribe = bridge_uninit.target.add_zone_status_subscriber(first_events.append)
+    bridge_uninit.target.add_zone_status_subscriber(second_events.append)
+
+    await bridge_uninit.initialize(HWQSX_PROCESSOR)
+
+    initial_event = next(event for event in first_events if event.zone_id == "1999")
+    assert initial_event.device_id == "1999"
+    assert initial_event.origin is smartbridge.ZoneStatusEventOrigin.INITIAL
+    assert initial_event.status == {"Zone": {"href": "/zone/1999"}}
+    assert second_events == first_events
+
+    status: Dict[str, Any] = {
+        "Zone": {"href": "/zone/1999"},
+        "FutureDirection": "Opening",
+    }
+    bridge_uninit.leap.send_unsolicited(
+        Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneZoneStatus",
+                StatusCode=ResponseStatus(200, "OK"),
+                Url="/zone/1999/status",
+            ),
+            Body={"ZoneStatus": status},
+        )
+    )
+    status["FutureDirection"] = "changed after delivery"
+    status["Zone"]["href"] = "/zone/changed-after-delivery"
+
+    update_event = first_events[-1]
+    assert update_event.origin is smartbridge.ZoneStatusEventOrigin.UPDATE
+    assert update_event.status["FutureDirection"] == "Opening"
+    assert update_event.status["Zone"]["href"] == "/zone/1999"
+    assert bridge_uninit.target.get_device_by_id("1999")["current_state"] == -1
+
+    unsubscribe()
+    unsubscribe()
+    bridge_uninit.leap.send_unsolicited(
+        Response(
+            CommuniqueType="ReadResponse",
+            Header=ResponseHeader(
+                MessageBodyType="OneZoneStatus",
+                StatusCode=ResponseStatus(200, "OK"),
+                Url="/zone/1999/status",
+            ),
+            Body={"ZoneStatus": {"Zone": {"href": "/zone/1999"}}},
+        )
+    )
+    assert first_events[-1] is update_event
+    assert second_events[-1].origin is smartbridge.ZoneStatusEventOrigin.UPDATE
+
+
+@pytest.mark.asyncio
+async def test_qsx_reconnect_zone_status_is_initial(bridge_uninit: Bridge):
+    """Test reconnect subscription snapshots are not reported as live updates."""
+    events: List[smartbridge.ZoneStatusEvent] = []
+    bridge_uninit.target.add_zone_status_subscriber(events.append)
+    await bridge_uninit.initialize(HWQSX_PROCESSOR)
+    events.clear()
+
+    bridge_uninit.disconnect()
+    await bridge_uninit.accept_connection(HWQSX_PROCESSOR)
+
+    assert events
+    assert all(
+        event.origin is smartbridge.ZoneStatusEventOrigin.INITIAL for event in events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -2426,6 +2426,73 @@ async def test_qsx_reconnect_zone_status_is_initial(bridge_uninit: Bridge):
 
 
 @pytest.mark.asyncio
+async def test_caseta_initial_and_reconnect_zone_status_is_initial(
+    bridge_uninit: Bridge,
+):
+    """Test explicit Caseta status reads are reported as snapshots."""
+    events: List[smartbridge.ZoneStatusEvent] = []
+    bridge_uninit.target.add_zone_status_subscriber(events.append)
+
+    await bridge_uninit.initialize(CASETA_PROCESSOR)
+    assert events
+    assert all(
+        event.origin is smartbridge.ZoneStatusEventOrigin.INITIAL for event in events
+    ), [(event.zone_id, event.origin) for event in events]
+
+    events.clear()
+    bridge_uninit.disconnect()
+    await bridge_uninit.accept_connection(CASETA_PROCESSOR)
+
+    assert events
+    assert all(
+        event.origin is smartbridge.ZoneStatusEventOrigin.INITIAL for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_zone_status_subscriptions_are_independent(bridge_uninit: Bridge):
+    """Test duplicate callbacks unsubscribe independently and isolate failures."""
+    with pytest.raises(TypeError):
+        bridge_uninit.target.add_zone_status_subscriber(cast(Any, None))
+
+    events: List[smartbridge.ZoneStatusEvent] = []
+    unsubscribe_first = bridge_uninit.target.add_zone_status_subscriber(events.append)
+    unsubscribe_second = bridge_uninit.target.add_zone_status_subscriber(events.append)
+
+    def raise_from_subscriber(_event: smartbridge.ZoneStatusEvent) -> None:
+        raise RuntimeError("subscriber failed")
+
+    def send_zone_update() -> None:
+        bridge_uninit.leap.send_unsolicited(
+            Response(
+                CommuniqueType="ReadResponse",
+                Header=ResponseHeader(
+                    MessageBodyType="OneZoneStatus",
+                    StatusCode=ResponseStatus(200, "OK"),
+                    Url="/zone/1999/status",
+                ),
+                Body={"ZoneStatus": {"Zone": {"href": "/zone/1999"}}},
+            )
+        )
+
+    await bridge_uninit.initialize(HWQSX_PROCESSOR)
+    events.clear()
+    unsubscribe_raising = bridge_uninit.target.add_zone_status_subscriber(
+        raise_from_subscriber
+    )
+
+    unsubscribe_first()
+    unsubscribe_first()
+    send_zone_update()
+    assert len(events) == 1
+
+    unsubscribe_raising()
+    unsubscribe_second()
+    send_zone_update()
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
 async def test_qsx_set_whitetune_level(qsx_processor: Bridge):
     """
     Test that setting the level of a White Tune zone without a fade time produces the


### PR DESCRIPTION
## Summary

- add an immutable `ZoneStatusEvent` containing the zone ID, resolved device ID, raw status payload, and delivery origin
- add opt-in, multi-subscriber `subscribe_zone_status(callback)` and `unsubscribe_zone_status(callback)` methods
- distinguish snapshots from notifications without implying change detection or deduplication
- publish events after existing device-state processing while preserving attributes that pylutron-caseta does not currently interpret

## Motivation

pylutron-caseta already receives zone-status messages from Lutron processors, but consumers can observe them only indirectly through the normalized device-state subscriber. That interface works well for entities that reread a known property after a notification. It does not provide enough information for consumers that need to:

- observe a notification that contains no recognized state attribute
- distinguish initialization or reconnection snapshots from notifications
- retain attributes introduced by another device type or future Lutron firmware
- allow more than one independent consumer to observe the same event
- remove a subscription cleanly during consumer shutdown

`add_subscriber()` currently stores one callback per device, passes no event payload, provides no delivery-origin metadata, and has no explicit unsubscribe method. Delivering raw events through that callback would change its established contract. Unifying the existing device, button, occupancy, and related subscriber mechanisms would also broaden this change into restructuring existing notification paths, including their ordering and error-handling behavior.

This contribution adds a separate zone-status API using the paired registration/removal pattern already used by `LeapProtocol` unsolicited listeners. Existing subscribers and normalized device-state behavior remain unchanged. The new listeners observe messages Smartbridge already processes; they do not create additional protocol subscriptions. When nobody subscribes, no event payload is copied or constructed.

## API and general applicability

Register and remove a listener using the same callback:

```python
bridge.subscribe_zone_status(handle_zone_status)
# During consumer shutdown:
bridge.unsubscribe_zone_status(handle_zone_status)
```

Each subscribe call adds one registration, including duplicate callbacks. Each unsubscribe call removes one matching registration and raises `ValueError` if none exists, following the low-level unsolicited-listener API.

Each subscriber receives a `ZoneStatusEvent`, for example:

```python
ZoneStatusEvent(
    zone_id="123",
    device_id="123",
    status={"Zone": {"href": "/zone/123"}},
    origin=ZoneStatusEventOrigin.SNAPSHOT,
)
```

- `SNAPSHOT` identifies status obtained from initialization reads or subscription responses, including reconnects.
- `NOTIFICATION` identifies status delivered through a notification callback.

These values describe the delivery path, not whether a value changed, and do not guarantee an ordering between snapshots and notifications. A reconnect snapshot may contain changes made while disconnected. A notification may repeat unchanged values or concern attributes a consumer does not use. Both are processed normally and delivered without deduplication. Neither origin proves that a command or physical movement occurred.

The raw status is copied into recursively immutable containers before delivery. One subscriber cannot modify the event observed by another, and later mutation of the decoded response cannot change an event already delivered. Subscriber exceptions are isolated and logged so they do not interrupt normal state processing or other raw-event subscribers.

The API is based on ordinary Lutron zone-status messages and is not limited to a particular zone type, processor model, room, or integration. It provides a general primitive for maintaining derived state, correlating separately known operations with processor notifications, reconciling or invalidating cached state, diagnostics, and observing attributes that pylutron-caseta does not yet normalize.

The library does not infer direction, position, command source, or intent from the event. Those interpretations remain the consumer's responsibility and must be based on available protocol evidence.

## Home Assistant context

This follows #208, which added discovery and Raise, Lower, and Stop commands for `OpenCloseStop` zones.

The immediate motivation is Home Assistant support for covers whose processor does not report physical position. Home Assistant can maintain an estimated position using calibrated travel time, correlate notifications with separately known actions, and invalidate the estimate after unexplained notifications or reconnects. This does not require treating every notification as proof of movement or ignoring changed state in snapshots.

This PR supplies only the general zone-event primitive. Position estimation, timing, command correlation, and user configuration remain outside pylutron-caseta.

## Compatibility

- existing per-device, button, occupancy, and Smart Away subscribers are unchanged
- normalized device-state mutation and existing device callbacks run before the new event is emitted
- consumers that do not register a zone-status subscriber incur no new event-copying work
- removing one callback registration does not remove other registrations
- raw-event subscriber failures do not prevent delivery to other raw-event subscribers

## Validation

- 67 tests pass on Python 3.10, 3.11, 3.12, 3.13, and 3.14
- Python 3.14 Ruff formatting/checks and mypy pass
- GitHub CI and Coveralls pass on the latest head, `b2c4a8a`
- wheel and source distribution build successfully as version `0.29.0`
- tests cover Caseta, RA3, and QSX reconnects; changed state delivered in reconnect snapshots; repeated identical notifications; multiple subscribers; callback registration and removal; subscriber failure isolation; unknown future attributes; and recursive payload immutability
