### PR TITLE
Add scene programming: read and write virtual button presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `BUTTON_STATUS_LONG_HOLD` constant for the `LongHold` LEAP button event
   emitted by HomeWorks QSX processors.
+- Scene programming: `get_scene_assignments` reads what a scene does, and
+  `set_scene` programs a scene's preset to an exact set of zone assignments
+  (creating, updating, and deleting the typed preset assignment resources),
+  optionally renaming the scene. Programming an unprogrammed virtual button
+  creates a new scene. Verified against a Caséta Smart Bridge Pro.
 
 ## [0.29.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,59 @@ reports direction, command, motion, or source attributes, support can be
 extended from captured protocol evidence without changing the general
 `OpenCloseStop` discovery classification.
 
+### Programming scenes
+
+Scenes are the bridge's virtual buttons; `activate_scene` presses one. The
+scene's contents — its preset's zone assignments — can also be read and
+written:
+
+```py
+# What does the scene do today?
+assignments = await bridge.get_scene_assignments("1")
+
+# Make the scene set one light to 75% and open one shade,
+# removing anything else it previously contained.
+await bridge.set_scene(
+    "1",
+    [
+        {"device_id": "2", "level": 75},
+        {"device_id": "7", "level": 100},
+    ],
+)
+```
+
+`set_scene` diffs by zone: it updates assignments in place (skipping ones
+that already match), creates missing ones, and deletes assignments for
+zones no longer listed. An empty list clears the scene. Programming an
+unprogrammed virtual button turns it into a scene; pass `name=` to name it
+(at most 50 characters — the bridge rejects longer names). Assignments may
+name a `device_id` or a `zone_id` (as `get_scene_assignments` reports), so
+what was read can be edited and written back.
+
+Assignments may carry `fade_time` and `delay_time` as decimal seconds
+(`"2"`, `"0.5"`, numbers, or timedeltas); the bridge rejects `hh:mm:ss`
+and ISO durations like `"PT4S"` here, unlike the zone command processor.
+Fade applies only to Dimmed zones, and delay only when an assignment is
+created; both are silently ignored where they do not apply. The assignment
+type is chosen from the zone's `ControlType`
+(`Dimmed`, `Switched`, or `Shade`); a zone can appear in a scene at most
+once, which the bridge itself enforces. Writes cost a few hundred
+milliseconds per changed assignment on a Smart Bridge Pro, so treat scene
+programming as a save-time operation, not something to do in the path of a
+command.
+
+These operations were verified against a Caséta Smart Bridge Pro,
+including the shape of real preset bodies: alongside the typed assignment
+collections, a preset carries `PresetAssignments` — the legacy untyped
+view, which mirrors the typed assignments one for one and is read-only —
+and that collection is recognized and ignored. Presets can also hold
+assignment kinds this library does not manage yet — fan speeds on Caséta,
+and the richer typed resources of RA3 and HomeWorks QSX processors
+(receptacles, color tuning, and others). `get_scene_assignments` does not
+report them, and `set_scene` refuses such a scene rather than silently
+leaving those assignments behind; support can be extended from captured
+protocol evidence.
+
 ### The leap tool
 
 For development and testing of new features, there is a `leap` command in the cli extras (`pip install pylutron_caseta[cli]`) which can be used for communicating directly with the bridge, similar to using `curl`.

--- a/src/pylutron_caseta/smartbridge.py
+++ b/src/pylutron_caseta/smartbridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import math
+import re
 import socket
 import ssl
 from datetime import timedelta
@@ -38,6 +39,37 @@ PING_INTERVAL = 60.0
 CONNECT_TIMEOUT = 5.0
 REQUEST_TIMEOUT = 5.0
 RECONNECT_DELAY = 2.0
+
+# The bridge rejects a virtual button Name longer than 50 characters
+# (characters, not bytes) with "400 The json request is malformed".
+SCENE_NAME_MAX_LENGTH = 50
+
+# A Preset body also carries "PresetAssignments" — the legacy untyped view
+# (AffectedZone/Level/Fade/Delay), which mirrors the typed assignments below
+# one for one and shares their id space. It is read-only and ignored here.
+_LEGACY_ASSIGNMENT_COLLECTION = "PresetAssignments"
+
+# Zone ControlType -> (collection key on the Preset body, assignment body key,
+# creation path segment under the preset). These are the typed preset
+# assignment resources; each zone may appear in a preset at most once (the
+# bridge refuses a second assignment for the same zone).
+_SCENE_ASSIGNMENT_KINDS = {
+    "Dimmed": (
+        "DimmedLevelAssignments",
+        "DimmedLevelAssignment",
+        "dimmedlevelassignment",
+    ),
+    "Switched": (
+        "SwitchedLevelAssignments",
+        "SwitchedLevelAssignment",
+        "switchedlevelassignment",
+    ),
+    "Shade": (
+        "ShadeLevelAssignments",
+        "ShadeLevelAssignment",
+        "shadelevelassignment",
+    ),
+}
 
 
 class Smartbridge:
@@ -613,6 +645,326 @@ class Smartbridge:
                 f"/virtualbutton/{scene_id}/commandprocessor",
                 {"Command": {"CommandType": "PressAndRelease"}},
             )
+
+    async def get_scene_assignments(self, scene_id: str) -> List[dict]:
+        """
+        Read what a scene does: the zone assignments of its preset.
+
+        Each entry describes one zone in the scene: ``assignment_id``,
+        ``href``, ``zone_href`` (the assignment's raw target), ``zone_id``
+        and ``device_id`` (None when the target is not a zone or matches no
+        known device), ``control_type`` ("Dimmed", "Switched" or "Shade"),
+        ``level`` (0-100; a Switched zone reports 100 for On and 0 for
+        Off), ``fade_time`` and ``delay_time`` (decimal seconds as strings,
+        e.g. "2" or "0.5", or None when the assignment does not carry
+        them).
+
+        Only Dimmed, Switched, and Shade assignments are reported; a preset
+        may also hold assignment kinds this library does not yet read (fan
+        speeds, for example), and those are not included.
+
+        :param scene_id: scene id, e.g. 23
+        :raises BridgeResponseError: when the scene does not exist
+        :raises ValueError: for a virtual button with no programming model
+            or preset (a scene Pico's, for example)
+        """
+        preset_href, _ = await self._get_scene_preset_href(scene_id)
+        assignments, _ = await self._read_scene_assignments(preset_href)
+        return assignments
+
+    async def set_scene(
+        self,
+        scene_id: str,
+        assignments: List[dict],
+        name: Optional[str] = None,
+    ):
+        """
+        Program a scene so its preset contains exactly ``assignments``.
+
+        The change is a diff by zone: assignments for new zones are created,
+        assignments whose values changed are updated in place, and
+        assignments for zones no longer listed are deleted. An empty list
+        clears the scene. Programming an unprogrammed virtual button turns
+        it into a scene; pass ``name`` to name it.
+
+        Each assignment is a dict with ``device_id`` (a device with a
+        zone) or ``zone_id`` (as reported by ``get_scene_assignments``),
+        and ``level`` (0-100; for a Switched zone any level above 0 means
+        On), and optionally ``fade_time`` and ``delay_time`` (decimal
+        seconds — strings, numbers, or timedeltas; note this differs from
+        ``set_value``'s hh:mm:ss ``fade_time``). Fade time applies only to
+        Dimmed zones; when omitted, an updated assignment keeps its current
+        fade and a new one gets "2" (the default fade). Delay applies only
+        at creation, where it defaults to "0"; both are silently ignored
+        where they do not apply.
+
+        Programming writes are save-time operations: expect a few hundred
+        milliseconds per changed assignment. Input validation runs before
+        the first write, but a bridge error partway through leaves the
+        scene partially written — re-read it with
+        ``get_scene_assignments``. Concurrent ``set_scene`` calls for the
+        same scene are unsupported (both diff the same snapshot). With an
+        empty list, ``name`` still renames the (now unprogrammed) virtual
+        button.
+
+        :param scene_id: scene id, e.g. 23
+        :param assignments: the scene's new contents, one entry per zone
+        :param name: optionally rename the scene (at most 50 characters)
+        :raises ValueError: for a name over 50 characters, an assignment
+            naming neither (or disagreeing) ``device_id``/``zone_id``, a
+            device without a zone, a zone whose control type cannot be in
+            a preset, a duplicate zone, a level outside 0-100, a bad fade
+            or delay, or a preset holding assignments this library cannot
+            manage
+        :raises BridgeResponseError: when the scene or a named zone does
+            not exist
+        :raises KeyError: for a ``device_id`` not known to the bridge
+        """
+        if name is not None and len(name) > SCENE_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"scene name may be at most {SCENE_NAME_MAX_LENGTH} characters"
+            )
+        wanted = await self._normalize_scene_assignments(assignments)
+
+        preset_href, button_name = await self._get_scene_preset_href(scene_id)
+        current, unknown_kinds = await self._read_scene_assignments(preset_href)
+        if unknown_kinds:
+            raise ValueError(
+                f"scene {scene_id} holds assignment kinds this library "
+                f"cannot manage: {', '.join(sorted(unknown_kinds))}"
+            )
+        not_zones = [
+            entry["href"]
+            for entry in current
+            if not entry["zone_href"].startswith("/zone/")
+        ]
+        if not_zones:
+            raise ValueError(
+                f"scene {scene_id} holds assignments this library cannot "
+                f"manage (not zone targets): {', '.join(sorted(not_zones))}"
+            )
+        # diff on the full resource href, never a bare id (ids repeat across
+        # resource types)
+        have = {entry["zone_href"]: entry for entry in current}
+
+        for zone_id, (assignment, control_type) in wanted.items():
+            _, body_key, segment = _SCENE_ASSIGNMENT_KINDS[control_type]
+            existing = have.get(f"/zone/{zone_id}")
+            if existing is not None and existing["control_type"] != control_type:
+                # the zone's ControlType changed since the assignment was
+                # made (e.g. a dimmer swapped for a switch): the old resource
+                # cannot take the new kind's body. The recreate keeps the old
+                # delay unless the caller gave one.
+                await self._request("DeleteRequest", existing["href"])
+                if assignment["delay_time"] is None:
+                    assignment["delay_time"] = existing["delay_time"]
+                existing = None
+            body = self._scene_assignment_body(
+                assignment, control_type, existing, zone_id
+            )
+            if existing is None:
+                await self._request(
+                    "CreateRequest", f"{preset_href}/{segment}", {body_key: body}
+                )
+            elif self._scene_assignment_differs(existing, body):
+                await self._request("UpdateRequest", existing["href"], {body_key: body})
+        for zone_href, existing in have.items():
+            if id_from_href(zone_href) not in wanted:
+                await self._request("DeleteRequest", existing["href"])
+
+        # the cache reflects the assignment writes even if the rename below
+        # fails, and never claims a name the bridge did not accept; an
+        # exception before this point may still leave the scene partially
+        # written on the bridge (re-read with get_scene_assignments)
+        if not wanted:
+            # every assignment was deleted: the virtual button is no longer
+            # a programmed scene
+            self.scenes.pop(scene_id, None)
+        else:
+            self.scenes[scene_id] = {"scene_id": scene_id, "name": button_name}
+        if name is not None and name != button_name:
+            await self._request(
+                "UpdateRequest",
+                f"/virtualbutton/{scene_id}",
+                {"VirtualButton": {"Name": name}},
+            )
+            if wanted:
+                self.scenes[scene_id]["name"] = name
+
+    async def _normalize_scene_assignments(
+        self, assignments: List[dict]
+    ) -> Dict[str, Tuple[dict, str]]:
+        """Validate ``set_scene`` input before any write.
+
+        Returns zone id -> (normalized assignment, the zone's ControlType);
+        raises ValueError so a bad entry cannot leave a scene half-written.
+        """
+        wanted: Dict[str, Tuple[dict, str]] = {}
+        for assignment in assignments:
+            zone_id = assignment.get("zone_id")
+            if zone_id is not None:
+                zone_id = str(zone_id)
+            device_id = assignment.get("device_id")
+            if device_id is not None:
+                device_zone = self._get_zone_id(str(device_id))
+                if zone_id is None:
+                    if not device_zone:
+                        raise ValueError(
+                            f"device {device_id} has no zone and cannot be "
+                            "in a scene"
+                        )
+                    zone_id = device_zone
+                elif device_zone != zone_id:
+                    raise ValueError(
+                        f"assignment names device {device_id} (zone "
+                        f"{device_zone}) but zone_id {zone_id}"
+                    )
+            if zone_id is None:
+                raise ValueError("assignment needs a device_id or a zone_id")
+            if zone_id in wanted:
+                raise ValueError(
+                    f"duplicate zone {zone_id}: a scene holds at most one "
+                    "assignment per zone"
+                )
+            level = float(assignment["level"])
+            if not 0 <= level <= 100:
+                raise ValueError(f"level {level} is outside 0-100")
+            fade = assignment.get("fade_time")
+            delay = assignment.get("delay_time")
+            normalized = {
+                "level": level,
+                "fade_time": None if fade is None else _leap_seconds(fade),
+                "delay_time": None if delay is None else _leap_seconds(delay),
+            }
+            control_type = await self._get_zone_control_type(zone_id)
+            if control_type not in _SCENE_ASSIGNMENT_KINDS:
+                raise ValueError(
+                    f"zone {zone_id} has control type {control_type!r}, "
+                    "which cannot be in a preset"
+                )
+            wanted[zone_id] = (normalized, control_type)
+        return wanted
+
+    async def _get_scene_preset_href(self, scene_id: str) -> Tuple[str, str]:
+        """Walk virtual button -> programming model -> preset.
+
+        Returns the preset href and the virtual button's current name.
+        """
+        response = await self._request("ReadRequest", f"/virtualbutton/{scene_id}")
+        virtual_button = (response.Body or {}).get("VirtualButton", {})
+        button_name = virtual_button.get("Name", "")
+        model_href = (virtual_button.get("ProgrammingModel") or {}).get("href")
+        if model_href is None:
+            raise ValueError(f"scene {scene_id} has no programming model")
+        response = await self._request("ReadRequest", model_href)
+        model = (response.Body or {}).get("ProgrammingModel", {})
+        preset_href = (model.get("Preset") or {}).get("href")
+        if preset_href is None:
+            raise ValueError(f"scene {scene_id} has no preset")
+        return preset_href, button_name
+
+    async def _read_scene_assignments(
+        self, preset_href: str
+    ) -> Tuple[List[dict], List[str]]:
+        """Read a preset's typed assignment resources.
+
+        Returns the assignments of the kinds this library manages, and the
+        names of any other non-empty assignment collections on the preset.
+        """
+        response = await self._request("ReadRequest", preset_href)
+        preset = (response.Body or {}).get("Preset", {})
+        known_collections = {
+            collection for collection, _, _ in _SCENE_ASSIGNMENT_KINDS.values()
+        }
+        unknown_kinds = [
+            key
+            for key, value in preset.items()
+            if key.endswith("Assignments")
+            and key not in known_collections
+            and key != _LEGACY_ASSIGNMENT_COLLECTION
+            and value
+        ]
+        assignments: List[dict] = []
+        for control_type, (collection, body_key, _) in _SCENE_ASSIGNMENT_KINDS.items():
+            for ref in preset.get(collection) or []:
+                response = await self._request("ReadRequest", ref["href"])
+                body = (response.Body or {}).get(body_key, {})
+                zone_href = (body.get("AssignableResource") or {}).get("href", "")
+                is_zone = zone_href.startswith("/zone/")
+                zone_id = id_from_href(zone_href) if is_zone else None
+                device_id: Optional[str] = None
+                if zone_id is not None:
+                    try:
+                        device_id = self.get_device_by_zone_id(zone_id)["device_id"]
+                    except KeyError:
+                        pass
+                if control_type == "Switched":
+                    level = 100 if body.get("SwitchedLevel") == "On" else 0
+                else:
+                    level = int(body.get("Level", 0))
+                assignments.append(
+                    {
+                        "assignment_id": id_from_href(ref["href"]),
+                        "href": ref["href"],
+                        "zone_id": zone_id,
+                        "zone_href": zone_href,
+                        "device_id": device_id,
+                        "control_type": control_type,
+                        "level": level,
+                        "fade_time": body.get("FadeTime"),
+                        "delay_time": body.get("DelayTime"),
+                    }
+                )
+        return assignments, unknown_kinds
+
+    async def _get_zone_control_type(self, zone_id: str) -> str:
+        """Read a zone's ControlType (selects its preset assignment type)."""
+        response = await self._request("ReadRequest", f"/zone/{zone_id}")
+        return ((response.Body or {}).get("Zone") or {}).get("ControlType", "")
+
+    @staticmethod
+    def _scene_assignment_body(
+        assignment: dict,
+        control_type: str,
+        existing: Optional[dict],
+        zone_id: str,
+    ) -> dict:
+        """Build the LEAP body for one scene assignment write."""
+        body: dict
+        if control_type == "Dimmed":
+            fade = assignment["fade_time"]
+            if fade is None and existing is not None:
+                fade = existing["fade_time"]
+            body = {
+                "Level": int(round(assignment["level"])),
+                "FadeTime": fade if fade is not None else "2",
+            }
+        elif control_type == "Switched":
+            body = {"SwitchedLevel": "On" if assignment["level"] > 0 else "Off"}
+        else:
+            body = {"Level": int(round(assignment["level"]))}
+        if existing is None:
+            delay = assignment["delay_time"]
+            body = {
+                "AssignableResource": {"href": f"/zone/{zone_id}"},
+                **body,
+                "DelayTime": delay if delay is not None else "0",
+            }
+        return body
+
+    @staticmethod
+    def _scene_assignment_differs(existing: dict, body: dict) -> bool:
+        """Would writing ``body`` change the assignment on the bridge?"""
+        if "SwitchedLevel" in body:
+            existing_switched = "On" if existing["level"] > 0 else "Off"
+            if body["SwitchedLevel"] != existing_switched:
+                return True
+        elif body["Level"] != existing["level"]:
+            return True
+        fade = body.get("FadeTime")
+        if fade is not None and fade != existing["fade_time"]:
+            return True
+        return False
 
     async def activate_smart_away(self):
         """
@@ -1528,6 +1880,30 @@ class Smartbridge:
         for task in (self._monitor_task, self._ping_task, self._login_task):
             if task is not None and not task.done():
                 task.cancel()
+
+
+def _leap_seconds(value: Union[str, int, float, timedelta]) -> str:
+    """Format seconds for LEAP FadeTime/DelayTime: decimal-second strings.
+
+    Unlike the zone command processor's FadeTime (hh:mm:ss — see
+    ``_format_duration``), the preset assignment resources take decimal
+    seconds: the bridge accepts "2" or "0.5" but rejects "00:00:02" and ISO
+    durations like "PT4S".
+    """
+    if isinstance(value, timedelta):
+        value = value.total_seconds()
+    if isinstance(value, str):
+        if re.fullmatch(r"[0-9]+(\.[0-9]+)?", value) is None:
+            raise ValueError(
+                f'{value!r} is not a decimal number of seconds (e.g. "2", "0.5")'
+            )
+        return value
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"{value!r} is not a non-negative number of seconds")
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.4f}".rstrip("0").rstrip(".")
 
 
 def _format_duration(duration: timedelta) -> str:

--- a/tests/test_smartbridge.py
+++ b/tests/test_smartbridge.py
@@ -1579,6 +1579,605 @@ async def test_activate_scene(bridge: Bridge):
     task.cancel()
 
 
+def _read_response(url: str, body_type: str, body: dict) -> Response:
+    """Build a ReadResponse for scene programming tests."""
+    return Response(
+        CommuniqueType="ReadResponse",
+        Header=ResponseHeader(
+            MessageBodyType=body_type,
+            StatusCode=ResponseStatus(200, "OK"),
+            Url=url,
+        ),
+        Body=body,
+    )
+
+
+async def _serve(
+    leap,
+    communique_type: str,
+    url: str,
+    response: Optional[Response] = None,
+    body: Optional[dict] = None,
+):
+    """Answer the next request, asserting it is the expected one.
+
+    With no ``response``, answer an empty 200 — what a write gets back.
+    """
+    request, fut = await leap.requests.get()
+    assert request.communique_type == communique_type, request
+    assert request.url == url, request
+    if body is not None:
+        assert request.body == body, request
+    if response is None:
+        response = Response(
+            Header=ResponseHeader(StatusCode=ResponseStatus(200, "OK")), Body={}
+        )
+    fut.set_result(response)
+    leap.requests.task_done()
+
+
+async def _serve_scene_preset_walk(
+    leap, scene_id: str, preset_body: dict, button_name: str = "scene 1"
+) -> None:
+    """Serve the virtual button -> programming model -> preset reads."""
+    await _serve(
+        leap,
+        "ReadRequest",
+        f"/virtualbutton/{scene_id}",
+        _read_response(
+            f"/virtualbutton/{scene_id}",
+            "OneVirtualButtonDefinition",
+            {
+                "VirtualButton": {
+                    "href": f"/virtualbutton/{scene_id}",
+                    "Name": button_name,
+                    "ProgrammingModel": {"href": f"/programmingmodel/{scene_id}"},
+                }
+            },
+        ),
+    )
+    await _serve(
+        leap,
+        "ReadRequest",
+        f"/programmingmodel/{scene_id}",
+        _read_response(
+            f"/programmingmodel/{scene_id}",
+            "OneProgrammingModelDefinition",
+            {
+                "ProgrammingModel": {
+                    "href": f"/programmingmodel/{scene_id}",
+                    "Preset": {"href": f"/preset/{scene_id}"},
+                }
+            },
+        ),
+    )
+    await _serve(
+        leap,
+        "ReadRequest",
+        f"/preset/{scene_id}",
+        _read_response(
+            f"/preset/{scene_id}", "OnePresetDefinition", {"Preset": preset_body}
+        ),
+    )
+
+
+_SCENE_1_PRESET = {
+    "href": "/preset/1",
+    "DimmedLevelAssignments": [{"href": "/dimmedlevelassignment/9"}],
+    "SwitchedLevelAssignments": [{"href": "/switchedlevelassignment/33"}],
+    # the legacy untyped view mirrors the typed assignments and is ignored
+    "PresetAssignments": [
+        {"href": "/presetassignment/9"},
+        {"href": "/presetassignment/33"},
+    ],
+}
+
+_DIMMED_9 = _read_response(
+    "/dimmedlevelassignment/9",
+    "OneDimmedLevelAssignmentDefinition",
+    {
+        "DimmedLevelAssignment": {
+            "href": "/dimmedlevelassignment/9",
+            "AssignableResource": {"href": "/zone/1"},
+            "Level": 50,
+            "FadeTime": "2",
+            "DelayTime": "0",
+        }
+    },
+)
+
+_SWITCHED_33 = _read_response(
+    "/switchedlevelassignment/33",
+    "OneSwitchedLevelAssignmentDefinition",
+    {
+        "SwitchedLevelAssignment": {
+            "href": "/switchedlevelassignment/33",
+            "AssignableResource": {"href": "/zone/99"},
+            "SwitchedLevel": "On",
+            "DelayTime": "0",
+        }
+    },
+)
+
+
+def _zone_response(zone_id: str, control_type: str) -> Response:
+    return _read_response(
+        f"/zone/{zone_id}",
+        "OneZoneDefinition",
+        {
+            "Zone": {
+                "href": f"/zone/{zone_id}",
+                "ControlType": control_type,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_scene_assignments(bridge: Bridge):
+    """Test reading a scene's preset assignments."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.get_scene_assignments("1")
+    )
+    await _serve_scene_preset_walk(bridge.leap, "1", _SCENE_1_PRESET)
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", _DIMMED_9)
+    await _serve(
+        bridge.leap, "ReadRequest", "/switchedlevelassignment/33", _SWITCHED_33
+    )
+    assignments = await task
+    assert assignments == [
+        {
+            "assignment_id": "9",
+            "href": "/dimmedlevelassignment/9",
+            "zone_id": "1",
+            "zone_href": "/zone/1",
+            "device_id": "2",
+            "control_type": "Dimmed",
+            "level": 50,
+            "fade_time": "2",
+            "delay_time": "0",
+        },
+        {
+            "assignment_id": "33",
+            "href": "/switchedlevelassignment/33",
+            "zone_id": "99",
+            "zone_href": "/zone/99",
+            "device_id": None,
+            "control_type": "Switched",
+            "level": 100,
+            "fade_time": None,
+            "delay_time": "0",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_scene_diffs_by_zone(bridge: Bridge):
+    """Test that set_scene updates, creates, and deletes assignments."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene(
+            "1",
+            [
+                {"device_id": "2", "level": 75},
+                # naming the zone directly (as get_scene_assignments reports
+                # it) is equivalent to naming the device; ints coerce
+                {"zone_id": 6, "level": 100},
+            ],
+        )
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    await _serve(bridge.leap, "ReadRequest", "/zone/6", _zone_response("6", "Shade"))
+    await _serve_scene_preset_walk(
+        bridge.leap, "1", _SCENE_1_PRESET, button_name="renamed on the bridge"
+    )
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", _DIMMED_9)
+    await _serve(
+        bridge.leap, "ReadRequest", "/switchedlevelassignment/33", _SWITCHED_33
+    )
+    # zone 1 changed level: updated in place, keeping its fade
+    await _serve(
+        bridge.leap,
+        "UpdateRequest",
+        "/dimmedlevelassignment/9",
+        body={"DimmedLevelAssignment": {"Level": 75, "FadeTime": "2"}},
+    )
+    # zone 6 is new: created under the preset
+    await _serve(
+        bridge.leap,
+        "CreateRequest",
+        "/preset/1/shadelevelassignment",
+        body={
+            "ShadeLevelAssignment": {
+                "AssignableResource": {"href": "/zone/6"},
+                "Level": 100,
+                "DelayTime": "0",
+            }
+        },
+    )
+    # zone 99 is no longer in the scene: deleted
+    await _serve(
+        bridge.leap,
+        "DeleteRequest",
+        "/switchedlevelassignment/33",
+    )
+    await task
+    # with no name given, the cache picks up the bridge's current name
+    assert bridge.target.scenes["1"] == {
+        "scene_id": "1",
+        "name": "renamed on the bridge",
+    }
+
+
+@pytest.mark.asyncio
+async def test_set_scene_programs_an_empty_button_and_names_it(bridge: Bridge):
+    """Test that programming an unprogrammed virtual button creates a scene."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene(
+            "2",
+            [
+                {
+                    "device_id": "2",
+                    "level": 100,
+                    "fade_time": timedelta(milliseconds=500),
+                }
+            ],
+            name="scene 2",
+        )
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    await _serve_scene_preset_walk(
+        bridge.leap, "2", {"href": "/preset/2"}, button_name="Button 2"
+    )
+    await _serve(
+        bridge.leap,
+        "CreateRequest",
+        "/preset/2/dimmedlevelassignment",
+        body={
+            "DimmedLevelAssignment": {
+                "AssignableResource": {"href": "/zone/1"},
+                "Level": 100,
+                "FadeTime": "0.5",
+                "DelayTime": "0",
+            }
+        },
+    )
+    await _serve(
+        bridge.leap,
+        "UpdateRequest",
+        "/virtualbutton/2",
+        body={"VirtualButton": {"Name": "scene 2"}},
+    )
+    await task
+    assert bridge.target.scenes["2"] == {"scene_id": "2", "name": "scene 2"}
+
+
+@pytest.mark.asyncio
+async def test_set_scene_skips_unchanged_assignments_and_names(bridge: Bridge):
+    """Test that an unchanged assignment and an unchanged name send nothing."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene(
+            "1",
+            [{"device_id": "2", "level": 50}],  # matches the current assignment
+            name="scene 1",  # matches the current name
+        )
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    await _serve_scene_preset_walk(
+        bridge.leap,
+        "1",
+        {
+            "href": "/preset/1",
+            "DimmedLevelAssignments": [{"href": "/dimmedlevelassignment/9"}],
+        },
+    )
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", _DIMMED_9)
+    # the task completing after only the served reads proves nothing else
+    # was sent: no update, no create, no delete, no rename
+    await task
+
+
+@pytest.mark.asyncio
+async def test_set_scene_with_empty_list_clears_the_scene(bridge: Bridge):
+    """Test that an empty assignment list deletes everything."""
+    task = asyncio.get_running_loop().create_task(bridge.target.set_scene("1", []))
+    await _serve_scene_preset_walk(bridge.leap, "1", _SCENE_1_PRESET)
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", _DIMMED_9)
+    await _serve(
+        bridge.leap, "ReadRequest", "/switchedlevelassignment/33", _SWITCHED_33
+    )
+    await _serve(
+        bridge.leap,
+        "DeleteRequest",
+        "/dimmedlevelassignment/9",
+    )
+    await _serve(
+        bridge.leap,
+        "DeleteRequest",
+        "/switchedlevelassignment/33",
+    )
+    await task
+    # the virtual button is no longer a programmed scene
+    assert "1" not in bridge.target.scenes
+
+
+@pytest.mark.asyncio
+async def test_set_scene_creates_a_switched_assignment(bridge: Bridge):
+    """Test the Switched create body: SwitchedLevel, no Level, no FadeTime."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene(
+            "1", [{"device_id": "2", "level": 100, "delay_time": 1.5}]
+        )
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Switched"))
+    await _serve_scene_preset_walk(bridge.leap, "1", {"href": "/preset/1"})
+    await _serve(
+        bridge.leap,
+        "CreateRequest",
+        "/preset/1/switchedlevelassignment",
+        body={
+            "SwitchedLevelAssignment": {
+                "AssignableResource": {"href": "/zone/1"},
+                "SwitchedLevel": "On",
+                "DelayTime": "1.5",
+            }
+        },
+    )
+    await task
+
+
+@pytest.mark.asyncio
+async def test_set_scene_updates_a_switched_assignment_only_on_change(
+    bridge: Bridge,
+):
+    """Test the Switched update body (On -> Off) and the unchanged-On skip."""
+    switched_1 = _read_response(
+        "/switchedlevelassignment/40",
+        "OneSwitchedLevelAssignmentDefinition",
+        {
+            "SwitchedLevelAssignment": {
+                "href": "/switchedlevelassignment/40",
+                "AssignableResource": {"href": "/zone/1"},
+                "SwitchedLevel": "On",
+                "DelayTime": "0",
+            }
+        },
+    )
+    preset = {
+        "href": "/preset/1",
+        "SwitchedLevelAssignments": [{"href": "/switchedlevelassignment/40"}],
+    }
+
+    # On -> Off: updated; delay_time is ignored for an existing assignment
+    # (the asserted body carries no DelayTime)
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "2", "level": 0, "delay_time": 5}])
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Switched"))
+    await _serve_scene_preset_walk(bridge.leap, "1", preset)
+    await _serve(bridge.leap, "ReadRequest", "/switchedlevelassignment/40", switched_1)
+    await _serve(
+        bridge.leap,
+        "UpdateRequest",
+        "/switchedlevelassignment/40",
+        body={"SwitchedLevelAssignment": {"SwitchedLevel": "Off"}},
+    )
+    await task
+
+    # already On: the task completing after only the reads proves no write
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "2", "level": 100}])
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Switched"))
+    await _serve_scene_preset_walk(bridge.leap, "1", preset)
+    await _serve(bridge.leap, "ReadRequest", "/switchedlevelassignment/40", switched_1)
+    await task
+
+
+@pytest.mark.asyncio
+async def test_set_scene_replaces_an_assignment_whose_control_type_changed(
+    bridge: Bridge,
+):
+    """Test that a zone whose ControlType changed is deleted and recreated."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "2", "level": 100}])
+    )
+    # zone 1 now reads Switched, but its existing assignment is Dimmed,
+    # with a 3 s delay the recreate must keep
+    delayed_dimmed = _read_response(
+        "/dimmedlevelassignment/9",
+        "OneDimmedLevelAssignmentDefinition",
+        {
+            "DimmedLevelAssignment": {
+                "href": "/dimmedlevelassignment/9",
+                "AssignableResource": {"href": "/zone/1"},
+                "Level": 50,
+                "FadeTime": "2",
+                "DelayTime": "3",
+            }
+        },
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Switched"))
+    await _serve_scene_preset_walk(
+        bridge.leap,
+        "1",
+        {
+            "href": "/preset/1",
+            "DimmedLevelAssignments": [{"href": "/dimmedlevelassignment/9"}],
+        },
+    )
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", delayed_dimmed)
+    await _serve(
+        bridge.leap,
+        "DeleteRequest",
+        "/dimmedlevelassignment/9",
+    )
+    await _serve(
+        bridge.leap,
+        "CreateRequest",
+        "/preset/1/switchedlevelassignment",
+        body={
+            "SwitchedLevelAssignment": {
+                "AssignableResource": {"href": "/zone/1"},
+                "SwitchedLevel": "On",
+                "DelayTime": "3",
+            }
+        },
+    )
+    await task
+
+
+@pytest.mark.asyncio
+async def test_scene_assignments_targeting_non_zones_are_reported_and_refused(
+    bridge: Bridge,
+):
+    """Test an assignment whose target is not a zone: read reports it with
+    zone_id None; set_scene refuses the scene rather than mistargeting it."""
+    group_dimmed = _read_response(
+        "/dimmedlevelassignment/9",
+        "OneDimmedLevelAssignmentDefinition",
+        {
+            "DimmedLevelAssignment": {
+                "href": "/dimmedlevelassignment/9",
+                "AssignableResource": {"href": "/zonegroup/5"},
+                "Level": 50,
+                "FadeTime": "2",
+                "DelayTime": "0",
+            }
+        },
+    )
+    preset = {
+        "href": "/preset/1",
+        "DimmedLevelAssignments": [{"href": "/dimmedlevelassignment/9"}],
+    }
+
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.get_scene_assignments("1")
+    )
+    await _serve_scene_preset_walk(bridge.leap, "1", preset)
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", group_dimmed)
+    assignments = await task
+    assert assignments[0]["zone_href"] == "/zonegroup/5"
+    assert assignments[0]["zone_id"] is None
+    assert assignments[0]["device_id"] is None
+
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "2", "level": 75}])
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    await _serve_scene_preset_walk(bridge.leap, "1", preset)
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", group_dimmed)
+    with pytest.raises(ValueError, match="not zone targets"):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_get_scene_assignments_rejects_a_button_with_no_program(
+    bridge: Bridge,
+):
+    """Test a virtual button with no ProgrammingModel (a scene Pico's)."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.get_scene_assignments("1")
+    )
+    await _serve(
+        bridge.leap,
+        "ReadRequest",
+        "/virtualbutton/1",
+        _read_response(
+            "/virtualbutton/1",
+            "OneVirtualButtonDefinition",
+            {"VirtualButton": {"href": "/virtualbutton/1", "Name": "scene 1"}},
+        ),
+    )
+    with pytest.raises(ValueError, match="no programming model"):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_set_scene_refuses_unmanageable_assignment_kinds(bridge: Bridge):
+    """Test that a preset holding an unknown assignment kind is refused."""
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "2", "level": 75}])
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    await _serve_scene_preset_walk(
+        bridge.leap,
+        "1",
+        {
+            "href": "/preset/1",
+            "DimmedLevelAssignments": [{"href": "/dimmedlevelassignment/9"}],
+            "FanSpeedAssignments": [{"href": "/fanspeedassignment/17"}],
+        },
+    )
+    await _serve(bridge.leap, "ReadRequest", "/dimmedlevelassignment/9", _DIMMED_9)
+    with pytest.raises(ValueError, match="FanSpeedAssignments"):
+        await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "assignments",
+    [
+        # device 4 is an occupancy sensor: no zone
+        pytest.param([{"device_id": "4", "level": 50}], id="device-without-zone"),
+        pytest.param([{"device_id": "2", "level": 101}], id="level-out-of-range"),
+        # hh:mm:ss / ISO durations are not decimal seconds
+        pytest.param(
+            [{"device_id": "2", "level": 50, "fade_time": "00:00:02"}],
+            id="fade-hh-mm-ss",
+        ),
+        pytest.param(
+            [{"device_id": "2", "level": 50, "fade_time": -2}], id="fade-negative"
+        ),
+        # non-ASCII digits are not decimal seconds either
+        pytest.param(
+            [{"device_id": "2", "level": 50, "fade_time": "\u0662"}],
+            id="fade-unicode-digit",
+        ),
+        # device 2's zone is 1, not 6 — a disagreeing pair is refused
+        pytest.param(
+            [{"device_id": "2", "zone_id": "6", "level": 50}],
+            id="device-zone-disagreement",
+        ),
+        pytest.param([{"level": 50}], id="neither-device-nor-zone"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_set_scene_rejects_bad_assignments(bridge: Bridge, assignments):
+    """Test that a bad assignment raises with nothing served at all.
+
+    Validation runs before the first request, so a bad entry cannot leave
+    the scene half-written.
+    """
+    with pytest.raises(ValueError):
+        await bridge.target.set_scene("1", assignments)
+
+
+@pytest.mark.asyncio
+async def test_set_scene_rejects_bad_input(bridge: Bridge):
+    """Test the rejections that need a name or a zone read first."""
+    with pytest.raises(ValueError):
+        await bridge.target.set_scene("1", [], name="x" * 51)
+
+    # a zone whose control type has no preset assignment type is rejected
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene("1", [{"device_id": "3", "level": 50}])
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/2", _zone_response("2", "FanSpeed"))
+    with pytest.raises(ValueError):
+        await task
+
+    # two spellings of the same zone: refused after the first entry's zone
+    # read, before any write
+    task = asyncio.get_running_loop().create_task(
+        bridge.target.set_scene(
+            "1", [{"device_id": "2", "level": 50}, {"zone_id": "1", "level": 60}]
+        )
+    )
+    await _serve(bridge.leap, "ReadRequest", "/zone/1", _zone_response("1", "Dimmed"))
+    with pytest.raises(ValueError, match="duplicate zone"):
+        await task
+
+
 @pytest.mark.asyncio
 async def test_reconnect_eof(bridge: Bridge):
     """Test that SmartBridge can reconnect on disconnect."""


### PR DESCRIPTION
This PR adds the write side of scenes. The library can discover scenes and press them (`activate_scene`), but the scenes themselves have to be created and edited in the Lutron app. With this change an application (e.g. a Home Assistant scene editor) can read what a scene does, edit it, create new scenes, and delete them.

**API** — two methods on `Smartbridge`:

- `get_scene_assignments(scene_id)` — one dict per zone in the scene: level, fade, delay, control type, ids.
- `set_scene(scene_id, assignments, name=None)` — saves the scene: makes its preset match the given list exactly (creating, updating in place, and deleting the typed preset assignment resources as needed), optionally renaming it. An empty list clears the scene; programming an unprogrammed virtual button creates one.

```py
assignments = await bridge.get_scene_assignments("21")
assignments[0]["level"] = 30
await bridge.set_scene("21", assignments)
```

`set_scene` is deliberately declarative ("make the scene exactly this") rather than an add/update/remove family, because the diffing involves bridge behavior that belongs in the library, not in every caller: assignment ids repeat across resource types (matching keys on the full resource href), a zone whose device changed control type needs delete-and-recreate, the bridge enforces one assignment per zone, and each write costs a few hundred milliseconds so unchanged assignments are skipped. If you'd prefer finer-grained assignment operations as the public surface, the internals support layering them — happy to restructure. Also happy to split this into read-only + write PRs if that's easier to review.

**Verified on hardware** (a Caséta Smart Bridge Pro), including live creation, editing, activation, and clearing of a scene controlling a real dimmer. Notable protocol findings baked into the implementation and docs: preset bodies report each assignment twice (typed collections + a legacy untyped `PresetAssignments` list, which is recognized and skipped); `FadeTime`/`DelayTime` on these resources take decimal-second strings, not the `hh:mm:ss` used by the zone command processor; virtual button names cap at 50 characters. Presets holding assignment kinds not supported here (fan speeds, RA3/QSX tuning types) make `set_scene` raise rather than saving a scene that silently keeps rows the caller never saw — those kinds can be added from captured protocol evidence.

Scope of testing: verified against Caséta only; RA3/QSX untested. 19 new tests cover the diff paths (create/update/skip/delete), Switched semantics, control-type change, clear, rename, input validation (parametrized), the legacy collection, and non-zone targets.